### PR TITLE
default max_pool_size to 0 = unlimited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## (unreleased)
 
+* Changed default connection pool size limit is now 0 (unlimited).
+
 * Fixed allow new connections right away if pool can be increased
 
 ## v0.2.0 (2016-10-20)

--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -59,12 +59,22 @@ describe DB do
   end
 
   it "should raise if the sole connection is been used" do
-    with_dummy do |db|
+    with_dummy "dummy://host?max_pool_size=1&checkout_timeout=0.5" do |db|
       db.query "1" do |rs|
         expect_raises DB::PoolTimeout do
           db.scalar "2"
         end
       end
+    end
+  end
+
+  it "should use 'unlimited' connections by default" do
+    with_dummy "dummy://host?checkout_timeout=0.5" do |db|
+      rs = [] of DB::ResultSet
+      500.times do
+        rs << db.query "1"
+      end
+      DummyDriver::DummyConnection.connections.size.should eq(500)
     end
   end
 

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -196,10 +196,10 @@ def with_witness(count = 1)
   w.count.should eq(0), "The expected coverage was unmet"
 end
 
-def with_dummy
+def with_dummy(uri : String = "dummy://host?checkout_timeout=0.5")
   DummyDriver::DummyConnection.clear_connections
 
-  DB.open "dummy://host?checkout_timeout=0.5" do |db|
+  DB.open uri do |db|
     yield db
   end
 end

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -7,7 +7,7 @@ module DB
   # The connection pool can be configured from URI parameters:
   #
   #   - initial_pool_size (default 1)
-  #   - max_pool_size (default 1)
+  #   - max_pool_size (default 0 = unlimited)
   #   - max_idle_pool_size (default 1)
   #   - checkout_timeout (default 5.0)
   #   - retry_attempts (default 1)

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -31,7 +31,7 @@ module DB
     def connection_pool_options(params : HTTP::Params)
       {
         initial_pool_size:  params.fetch("initial_pool_size", 1).to_i,
-        max_pool_size:      params.fetch("max_pool_size", 1).to_i,
+        max_pool_size:      params.fetch("max_pool_size", 0).to_i,
         max_idle_pool_size: params.fetch("max_idle_pool_size", 1).to_i,
         checkout_timeout:   params.fetch("checkout_timeout", 5.0).to_f,
         retry_attempts:     params.fetch("retry_attempts", 1).to_i,

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -12,7 +12,7 @@ module DB
     @retry_attempts : Int32
     @retry_delay : Float64
 
-    def initialize(@initial_pool_size = 1, @max_pool_size = 1, @max_idle_pool_size = 1, @checkout_timeout = 5.0,
+    def initialize(@initial_pool_size = 1, @max_pool_size = 0, @max_idle_pool_size = 1, @checkout_timeout = 5.0,
                    @retry_attempts = 1, @retry_delay = 0.2, &@factory : -> T)
       @initial_pool_size.times { build_resource }
 
@@ -124,7 +124,7 @@ module DB
     end
 
     private def can_increase_pool
-      @total.size < @max_pool_size
+      @max_pool_size == 0 || @total.size < @max_pool_size
     end
 
     private def can_increase_idle_pool


### PR DESCRIPTION
We've been discussing what should be a default max_pool_size for database drivers.

Before this the default was 1. Which will be a common bottle neck for concurrent applications.

Other languages/libs defaults are:
- .net=100
- java jdbc=100
- ruby activerecord=2
- go=∞ (0 == ∞)

This PR changes the default to 0 meaning ∞ as in go.

cc: @asterite @waj 
