### PR TITLE
Add before_checkout/after_release callbacks for resources in pool

### DIFF
--- a/src/db/connection.cr
+++ b/src/db/connection.cr
@@ -28,6 +28,8 @@ module DB
     @statements_cache = StringKeyCache(Statement).new
     @transaction = false
     getter? prepared_statements : Bool
+    # :nodoc:
+    property auto_release : Bool = true
 
     def initialize(@database : Database)
       @prepared_statements = @database.prepared_statements?
@@ -61,8 +63,17 @@ module DB
     end
 
     # :nodoc:
+    protected def before_checkout
+      @auto_release = true
+    end
+
+    # :nodoc:
+    protected def after_release
+    end
+
+    # :nodoc:
     def release_from_statement
-      @database.return_to_pool(self) unless @transaction
+      @database.return_to_pool(self) if @auto_release && !@transaction
     end
 
     # :nodoc:

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -98,6 +98,7 @@ module DB
     # when the block ends
     def using_connection
       connection = @pool.checkout
+      connection.auto_release = false
       begin
         yield connection
       ensure

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -41,6 +41,7 @@ module DB
                  end
 
       @available.delete resource
+      resource.before_checkout
       resource
     end
 
@@ -56,6 +57,7 @@ module DB
         resource = ref.target
         if resource && is_available?(resource)
           @available.delete resource
+          resource.before_checkout
           return {resource, true}
         end
       end
@@ -67,6 +69,7 @@ module DB
     def release(resource : T) : Nil
       if can_increase_idle_pool
         @available << resource
+        resource.after_release
         @availability_channel.send nil if are_waiting_for_resource?
       else
         resource.close


### PR DESCRIPTION
add auto_release to DB::Connection (default true on each pool checkout).
fixes #35.