### PR TITLE
Add NamedTuple argument for quering on the DB

### DIFF
--- a/spec/dummy_driver_spec.cr
+++ b/spec/dummy_driver_spec.cr
@@ -138,7 +138,7 @@ describe DummyDriver do
         end
       end
 
-      it "with as named tuple" do
+      it "with a named tuple" do
         with_dummy do |db|
           db.query_one("3,4", as: {a: Int64, b: Int64}).should eq({a: 3i64, b: 4i64})
         end
@@ -182,6 +182,14 @@ describe DummyDriver do
         end
       end
 
+      it "with as" do
+        with_dummy do |db|
+          value = db.query_one?("3,4", as: {a: Int64, b: Int64})
+          value.should be_a(NamedTuple(a: Int64, b: Int64)?)
+          value.should eq({a: 3i64, b: 4i64})
+        end
+      end
+
       it "with as, just one" do
         with_dummy do |db|
           value = db.query_one?("3", as: Int64)
@@ -206,7 +214,7 @@ describe DummyDriver do
         end
       end
 
-      it "queries with as named tuple" do
+      it "queries with a named tuple" do
         with_dummy do |db|
           ary = db.query_all "3,4 1,2", as: {a: Int64, b: Int64}
           ary.should eq([{a: 3, b: 4}, {a: 1, b: 2}])

--- a/spec/dummy_driver_spec.cr
+++ b/spec/dummy_driver_spec.cr
@@ -138,6 +138,12 @@ describe DummyDriver do
         end
       end
 
+      it "with as named tuple" do
+        with_dummy do |db|
+          db.query_one("3,4", as: {a: Int64, b: Int64}).should eq({a: 3i64, b: 4i64})
+        end
+      end
+
       it "with as, just one" do
         with_dummy do |db|
           db.query_one("3", as: Int64).should eq(3i64)
@@ -197,6 +203,13 @@ describe DummyDriver do
         with_dummy do |db|
           ary = db.query_all "3,4 1,2", as: {Int64, Int64}
           ary.should eq([{3, 4}, {1, 2}])
+        end
+      end
+
+      it "queries with as named tuple" do
+        with_dummy do |db|
+          ary = db.query_all "3,4 1,2", as: {a: Int64, b: Int64}
+          ary.should eq([{a: 3, b: 4}, {a: 1, b: 2}])
         end
       end
 

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -88,6 +88,20 @@ module DB
       end
     end
 
+    # Executes a *query* that expects a single row and returns it
+    # as a named tuple of the given *types*.
+    #
+    # Raises `DB::Error` if there were no rows, or if there were more than one row.
+    #
+    # ```
+    # db.query_one "select name, age from contacts where id = ?", 1, as: {name, String, age : Int32}
+    # ```
+    def query_one(query, *args, as types : NamedTuple)
+      query_one(query, *args) do |rs|
+        rs.read(**types)
+      end
+    end
+
     # Executes a *query* that expects a single row
     # and returns the first column's value as the given *type*.
     #
@@ -121,6 +135,23 @@ module DB
         value = yield rs
         raise DB::Error.new("more than one row") if rs.move_next
         return value
+      end
+    end
+
+    # Executes a *query* that expects a single row and returns it
+    # as a named tuple of the given *types*.
+    #
+    # Returns `nil` if there were no rows.
+    #
+    # Raises `DB::Error` if there were more than one row.
+    #
+    # ```
+    # result = db.query_one? "select name, age from contacts where id = ?", 1, as: {name: String, age: Int32}
+    # typeof(result) # => Tuple(String, Int32) | Nil
+    # ```
+    def query_one?(query, *args, as types : Tuple)
+      query_one?(query, *args) do |rs|
+        rs.read(*types)
       end
     end
 
@@ -181,6 +212,18 @@ module DB
     def query_all(query, *args, as types : Tuple)
       query_all(query, *args) do |rs|
         rs.read(*types)
+      end
+    end
+
+    # Executes a *query* and returns an array where each row is
+    # read as a named tuple of the given *types*.
+    #
+    # ```
+    # contacts = db.query_all "select name, age from contacts", as: {name: String, age: Int32}
+    # ```
+    def query_all(query, *args, as types : NamedTuple)
+      query_all(query, *args) do |rs|
+        rs.read(**types)
       end
     end
 

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -157,6 +157,23 @@ module DB
     end
 
     # Executes a *query* that expects a single row and returns it
+    # as a tuple of the given *types*.
+    #
+    # Returns `nil` if there were no rows.
+    #
+    # Raises `DB::Error` if there were more than one row.
+    #
+    # ```
+    # result = db.query_one? "select name, age from contacts where id = ?", 1, as: {String, Int32}
+    # typeof(result) # => Tuple(String, Int32) | Nil
+    # ```
+    def query_one?(query, *args, as types : Tuple)
+      query_one?(query, *args) do |rs|
+        rs.read(*types)
+      end
+    end
+
+    # Executes a *query* that expects a single row and returns it
     # as a named tuple of the given *types* (the keys of the named tuple
     # are not necessarily the column names).
     #

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -173,6 +173,24 @@ module DB
       end
     end
 
+    # Executes a *query* that expects a single row and returns it
+    # as a named tuple of the given *types* (the keys of the named tuple
+    # are not necessarily the column names).
+    #
+    # Returns `nil` if there were no rows.
+    #
+    # Raises `DB::Error` if there were more than one row.
+    #
+    # ```
+    # result = db.query_one? "select name, age from contacts where id = ?", 1, as: {age: String, name: Int32}
+    # typeof(result) # => NamedTuple(age: String, name: Int32) | Nil
+    # ```
+    def query_one?(query, *args, as types : NamedTuple)
+      query_one(query, *args) do |rs|
+        rs.read(**types)
+      end
+    end
+
     # Executes a *query* that expects a single row
     # and returns the first column's value as the given *type*.
     #

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -155,6 +155,7 @@ module DB
         rs.read(*types)
       end
     end
+
     # Executes a *query* that expects a single row and returns it
     # as a named tuple of the given *types* (the keys of the named tuple
     # are not necessarily the column names).

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -89,12 +89,13 @@ module DB
     end
 
     # Executes a *query* that expects a single row and returns it
-    # as a named tuple of the given *types*.
+    # as a named tuple of the given *types* (the keys of the named tuple
+    # are not necessarily the column names).
     #
     # Raises `DB::Error` if there were no rows, or if there were more than one row.
     #
     # ```
-    # db.query_one "select name, age from contacts where id = ?", 1, as: {name, String, age : Int32}
+    # db.query_one "select name, age from contacts where id = ?", 1, as: {name: String, age: Int32}
     # ```
     def query_one(query, *args, as types : NamedTuple)
       query_one(query, *args) do |rs|
@@ -216,7 +217,8 @@ module DB
     end
 
     # Executes a *query* and returns an array where each row is
-    # read as a named tuple of the given *types*.
+    # read as a named tuple of the given *types* (the keys of the named tuple
+    # are not necessarily the column names).
     #
     # ```
     # contacts = db.query_all "select name, age from contacts", as: {name: String, age: Int32}

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -155,24 +155,6 @@ module DB
         rs.read(*types)
       end
     end
-
-    # Executes a *query* that expects a single row and returns it
-    # as a tuple of the given *types*.
-    #
-    # Returns `nil` if there were no rows.
-    #
-    # Raises `DB::Error` if there were more than one row.
-    #
-    # ```
-    # result = db.query_one? "select name, age from contacts where id = ?", 1, as: {String, Int32}
-    # typeof(result) # => Tuple(String, Int32) | Nil
-    # ```
-    def query_one?(query, *args, as types : Tuple)
-      query_one?(query, *args) do |rs|
-        rs.read(*types)
-      end
-    end
-
     # Executes a *query* that expects a single row and returns it
     # as a named tuple of the given *types* (the keys of the named tuple
     # are not necessarily the column names).

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -140,23 +140,6 @@ module DB
     end
 
     # Executes a *query* that expects a single row and returns it
-    # as a named tuple of the given *types*.
-    #
-    # Returns `nil` if there were no rows.
-    #
-    # Raises `DB::Error` if there were more than one row.
-    #
-    # ```
-    # result = db.query_one? "select name, age from contacts where id = ?", 1, as: {name: String, age: Int32}
-    # typeof(result) # => Tuple(String, Int32) | Nil
-    # ```
-    def query_one?(query, *args, as types : Tuple)
-      query_one?(query, *args) do |rs|
-        rs.read(*types)
-      end
-    end
-
-    # Executes a *query* that expects a single row and returns it
     # as a tuple of the given *types*.
     #
     # Returns `nil` if there were no rows.

--- a/src/db/result_set.cr
+++ b/src/db/result_set.cr
@@ -89,11 +89,26 @@ module DB
       internal_read(*types)
     end
 
+    # Reads the next columns and returns a named tuple of the values.
+    def read(**types : Class)
+      internal_read(**types)
+    end
+
     private def internal_read(*types : *T) forall T
       {% begin %}
         Tuple.new(
           {% for type in T %}
             read({{type.instance}}),
+          {% end %}
+        )
+      {% end %}
+    end
+
+    private def internal_read(**types : **T) forall T
+      {% begin %}
+        NamedTuple.new(
+          {% for name, type in T %}
+            {{ name }}: read({{type.instance}}),
           {% end %}
         )
       {% end %}


### PR DESCRIPTION
It is now possible to write

```crystal
# old way
DB.query_all("SELECT title, data FROM records;", as: {String, String}).
  map { |r| {title: r[0], custom_name: r[1] }

# new way
DB.query_all("SELECT title, data FROM records;", as: {title: String, custom_name: String})
```

Let me now if you want me to add unit test / ...
I'm not 100% sure of the details on my own work.

#55 