### PR TITLE
Release connection when query cannot be built

### DIFF
--- a/spec/database_spec.cr
+++ b/spec/database_spec.cr
@@ -149,6 +149,28 @@ describe DB::Database do
     end
   end
 
+  it "should return connection to the pool if prepared statement is unable to be built" do
+    connection = uninitialized DB::Connection
+    with_dummy "dummy://localhost:1027?initial_pool_size=1" do |db|
+      connection = DummyDriver::DummyConnection.connections.first
+      expect_raises do
+        db.prepared.exec("syntax error")
+      end
+      db.pool.is_available?(connection).should be_true
+    end
+  end
+
+  it "should return connection to the pool if unprepared statement is unable to be built" do
+    connection = uninitialized DB::Connection
+    with_dummy "dummy://localhost:1027?initial_pool_size=1" do |db|
+      connection = DummyDriver::DummyConnection.connections.first
+      expect_raises do
+        db.unprepared.exec("syntax error")
+      end
+      db.pool.is_available?(connection).should be_true
+    end
+  end
+
   describe "prepared_statements connection option" do
     it "defaults to true" do
       with_dummy "dummy://localhost:1027" do |db|

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -99,6 +99,7 @@ class DummyDriver < DB::Driver
     def initialize(connection, @query : String, @prepared : Bool)
       @params = Hash(Int32 | String, DB::Any).new
       super(connection)
+      raise query if query == "syntax error"
     end
 
     protected def perform_query(args : Enumerable)

--- a/src/db/pool_prepared_statement.cr
+++ b/src/db/pool_prepared_statement.cr
@@ -33,13 +33,14 @@ module DB
     private def build_statement
       clean_connections
       conn, existing = @db.checkout_some(@connections)
-      @connections << WeakRef.new(conn) unless existing
       begin
-        conn.prepared.build(@query)
+        stmt = conn.prepared.build(@query)
       rescue ex
         conn.release
         raise ex
       end
+      @connections << WeakRef.new(conn) unless existing
+      stmt
     end
 
     private def clean_connections

--- a/src/db/pool_prepared_statement.cr
+++ b/src/db/pool_prepared_statement.cr
@@ -34,7 +34,12 @@ module DB
       clean_connections
       conn, existing = @db.checkout_some(@connections)
       @connections << WeakRef.new(conn) unless existing
-      conn.prepared.build(@query)
+      begin
+        conn.prepared.build(@query)
+      rescue ex
+        conn.release
+        raise ex
+      end
     end
 
     private def clean_connections

--- a/src/db/pool_prepared_statement.cr
+++ b/src/db/pool_prepared_statement.cr
@@ -29,7 +29,7 @@ module DB
     end
 
     # builds a statement over a real connection
-    # the conneciton is registered in `@connections`
+    # the connection is registered in `@connections`
     private def build_statement
       clean_connections
       conn, existing = @db.checkout_some(@connections)

--- a/src/db/pool_unprepared_statement.cr
+++ b/src/db/pool_unprepared_statement.cr
@@ -15,7 +15,13 @@ module DB
 
     # builds a statement over a real connection
     private def build_statement
-      @db.pool.checkout.unprepared.build(@query)
+      conn = @db.pool.checkout
+      begin
+        conn.unprepared.build(@query)
+      rescue ex
+        conn.release
+        raise ex
+      end
     end
   end
 end


### PR DESCRIPTION
This was leaking connection when a query could not be build - ie if an invalid column name was used.
More info here - https://github.com/crystal-lang/crystal-mysql/issues/40