### PR TITLE
Updated exceptions so all exceptions can be caught from DB::Error

### DIFF
--- a/src/db/error.cr
+++ b/src/db/error.cr
@@ -2,7 +2,7 @@ module DB
   class Error < Exception
   end
 
-  class MappingException < Exception
+  class MappingException < Error
   end
 
   class PoolTimeout < Error
@@ -27,6 +27,6 @@ module DB
   class ConnectionRefused < Error
   end
 
-  class Rollback < Exception
+  class Rollback < Error
   end
 end


### PR DESCRIPTION
I noticed a few exceptions were being derived directly from `Exception` making them uncatchable with `DB::Error` and I fixed that.