### PR TITLE
The TEXT can always be read back as a String

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ require "sqlite3"
 
 DB.open "sqlite3:./file.db" do |db|
   # When using the pg driver, use $1, $2, etc. instead of ?
-  db.exec "create table contacts (name string, age integer)"
+  db.exec "create table contacts (name text, age integer)"
   db.exec "insert into contacts values (?, ?)", "John Doe", 30
 
   args = [] of DB::Any


### PR DESCRIPTION
If you store something like "1234" in a STRING field, SQLite will return
an Int64. Better to be more specific, for uses who play around with the
example code.

Resolves #49.