### PR TITLE
Add JSON::Any to DB::TYPES

### DIFF
--- a/src/db.cr
+++ b/src/db.cr
@@ -1,4 +1,5 @@
 require "uri"
+require "json"
 
 # The DB module is a unified interface to database access.
 # Database dialects is supported by custom database driver shards.
@@ -69,7 +70,7 @@ module DB
   # Types supported to interface with database driver.
   # These can be used in any `ResultSet#read` or any `Database#query` related
   # method to be used as query parameters
-  TYPES = [Nil, String, Bool, Int32, Int64, Float32, Float64, Time, Bytes]
+  TYPES = [Nil, String, Bool, Int32, Int64, Float32, Float64, Time, Bytes, JSON::Any]
 
   # See `DB::TYPES` in `DB`. `Any` is a union of all types in `DB::TYPES`
   {% begin %}


### PR DESCRIPTION
Enables reading out jsonb data from Postgres directly.
(Value returned is of type JSON::Any.)