### PR TITLE
Add travis nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: crystal
+crystal:
+  - latest
+  - nightly
 script:
   - crystal spec
   - crystal tool format --check


### PR DESCRIPTION
The cron schedule in travis is already configured to run daily.

https://travis-ci.org/crystal-lang/crystal-db/jobs/549939092 shows how the output for nightlies identifies the crystal version build