### PR TITLE
Statement#exec and #query require named argument for array values

### DIFF
--- a/spec/custom_drivers_types_spec.cr
+++ b/spec/custom_drivers_types_spec.cr
@@ -227,14 +227,14 @@ describe DB do
       db.query "query", 1, "string" { }
       db.query("query", Bytes.new(4)) { }
       db.query("query", 1, "string", FooValue.new(5)) { }
-      db.query "query", [1, "string", FooValue.new(5)] { }
+      db.query "query", args: [1, "string", FooValue.new(5)] { }
 
       db.query("query").close
       db.query("query", 1).close
       db.query("query", 1, "string").close
       db.query("query", Bytes.new(4)).close
       db.query("query", 1, "string", FooValue.new(5)).close
-      db.query("query", [1, "string", FooValue.new(5)]).close
+      db.query("query", args: [1, "string", FooValue.new(5)]).close
     end
 
     DB.open("bar://host") do |db|
@@ -244,14 +244,14 @@ describe DB do
       db.query "query", 1, "string" { }
       db.query("query", Bytes.new(4)) { }
       db.query("query", 1, "string", BarValue.new(5)) { }
-      db.query "query", [1, "string", BarValue.new(5)] { }
+      db.query "query", args: [1, "string", BarValue.new(5)] { }
 
       db.query("query").close
       db.query("query", 1).close
       db.query("query", 1, "string").close
       db.query("query", Bytes.new(4)).close
       db.query("query", 1, "string", BarValue.new(5)).close
-      db.query("query", [1, "string", BarValue.new(5)]).close
+      db.query("query", args: [1, "string", BarValue.new(5)]).close
     end
   end
 
@@ -263,7 +263,7 @@ describe DB do
       db.exec("query", 1, "string")
       db.exec("query", Bytes.new(4))
       db.exec("query", 1, "string", FooValue.new(5))
-      db.exec("query", [1, "string", FooValue.new(5)])
+      db.exec("query", args: [1, "string", FooValue.new(5)])
     end
 
     DB.open("bar://host") do |db|
@@ -273,20 +273,20 @@ describe DB do
       db.exec("query", 1, "string")
       db.exec("query", Bytes.new(4))
       db.exec("query", 1, "string", BarValue.new(5))
-      db.exec("query", [1, "string", BarValue.new(5)])
+      db.exec("query", args: [1, "string", BarValue.new(5)])
     end
   end
 
   it "Foo and Bar drivers should not implement each other params" do
     DB.open("foo://host") do |db|
       expect_raises Exception, "FooDriver::FooStatement does not support BarValue params" do
-        db.exec("query", [BarValue.new(5)])
+        db.exec("query", args: [BarValue.new(5)])
       end
     end
 
     DB.open("bar://host") do |db|
       expect_raises Exception, "BarDriver::BarStatement does not support FooValue params" do
-        db.exec("query", [FooValue.new(5)])
+        db.exec("query", args: [FooValue.new(5)])
       end
     end
   end

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -97,7 +97,7 @@ class DummyDriver < DB::Driver
     property params
 
     def initialize(connection, @query : String, @prepared : Bool)
-      @params = Hash(Int32 | String, DB::Any).new
+      @params = Hash(Int32 | String, DB::Any | Array(DB::Any)).new
       super(connection)
       raise DB::Error.new(query) if query == "syntax error"
     end
@@ -124,6 +124,10 @@ class DummyDriver < DB::Driver
 
     private def set_param(index, value : DB::Any)
       @params[index] = value
+    end
+
+    private def set_param(index, value : Array)
+      @params[index] = value.map(&.as(DB::Any))
     end
 
     private def set_param(index, value)

--- a/spec/statement_spec.cr
+++ b/spec/statement_spec.cr
@@ -51,6 +51,25 @@ describe DB::Statement do
     end
   end
 
+  it "allows no arguments" do
+    with_dummy_connection do |cnn|
+      stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)
+      stmt.query
+      stmt.params.should be_empty
+    end
+  end
+
+  it "concatenate arguments" do
+    with_dummy_connection do |cnn|
+      stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)
+      stmt.query 1, 2, args: ["a", [1, nil]]
+      stmt.params[0].should eq(1)
+      stmt.params[1].should eq(2)
+      stmt.params[2].should eq("a")
+      stmt.params[3].should eq([1, nil])
+    end
+  end
+
   it "should initialize positional params in query with array" do
     with_dummy_connection do |cnn|
       stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)
@@ -86,6 +105,25 @@ describe DB::Statement do
       stmt.params[0].should eq("a")
       stmt.params[1].should eq(1)
       stmt.params[2].should eq(nil)
+    end
+  end
+
+  it "allows no arguments" do
+    with_dummy_connection do |cnn|
+      stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)
+      stmt.exec
+      stmt.params.should be_empty
+    end
+  end
+
+  it "concatenate arguments" do
+    with_dummy_connection do |cnn|
+      stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)
+      stmt.exec 1, 2, args: ["a", [1, nil]]
+      stmt.params[0].should eq(1)
+      stmt.params[1].should eq(2)
+      stmt.params[2].should eq("a")
+      stmt.params[3].should eq([1, nil])
     end
   end
 

--- a/spec/statement_spec.cr
+++ b/spec/statement_spec.cr
@@ -43,10 +43,18 @@ describe DB::Statement do
     end
   end
 
-  it "should initialize positional params in query with array" do
+  it "accepts array as single argument" do
     with_dummy_connection do |cnn|
       stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)
       stmt.query ["a", 1, nil]
+      stmt.params[0].should eq(["a", 1, nil])
+    end
+  end
+
+  it "should initialize positional params in query with array" do
+    with_dummy_connection do |cnn|
+      stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)
+      stmt.query args: ["a", 1, nil]
       stmt.params[0].should eq("a")
       stmt.params[1].should eq(1)
       stmt.params[2].should eq(nil)
@@ -63,10 +71,18 @@ describe DB::Statement do
     end
   end
 
-  it "should initialize positional params in exec with array" do
+  it "accepts array as single argument" do
     with_dummy_connection do |cnn|
       stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)
       stmt.exec ["a", 1, nil]
+      stmt.params[0].should eq(["a", 1, nil])
+    end
+  end
+
+  it "should initialize positional params in exec with array" do
+    with_dummy_connection do |cnn|
+      stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)
+      stmt.exec args: ["a", 1, nil]
       stmt.params[0].should eq("a")
       stmt.params[1].should eq(1)
       stmt.params[2].should eq(nil)

--- a/src/db.cr
+++ b/src/db.cr
@@ -181,6 +181,7 @@ end
 
 require "./db/pool"
 require "./db/string_key_cache"
+require "./db/enumerable_concat"
 require "./db/query_methods"
 require "./db/session_methods"
 require "./db/disposable"

--- a/src/db/enumerable_concat.cr
+++ b/src/db/enumerable_concat.cr
@@ -1,0 +1,38 @@
+module DB
+  # :nodoc:
+  struct EnumerableConcat(S, T, U)
+    include Enumerable(S)
+
+    def initialize(@e1 : T, @e2 : U)
+    end
+
+    def each
+      if e1 = @e1
+        @e1.each do |e|
+          yield e
+        end
+      end
+      if e2 = @e2
+        e2.each do |e|
+          yield e
+        end
+      end
+    end
+
+    # returns given `e1 : T` an `Enumerable(T')` and `e2 : U` an `Enumerable(U') | Nil`
+    # it retuns and `Enumerable(T' | U')` that enumerates the elements of `e1`
+    # and, later, the elements of `e2`.
+    def self.build(e1 : T, e2 : U)
+      return e1 if e2.nil? || e2.empty?
+      return e2 if e1.nil? || e1.empty?
+      EnumerableConcat(Union(typeof(sample(e1)), typeof(sample(e2))), T, U).new(e1, e2)
+    end
+
+    private def self.sample(c : Enumerable?)
+      c.not_nil!.each do |e|
+        return e
+      end
+      raise ""
+    end
+  end
+end

--- a/src/db/pool_statement.cr
+++ b/src/db/pool_statement.cr
@@ -20,8 +20,8 @@ module DB
     end
 
     # See `QueryMethods#exec`
-    def exec(args : Array) : ExecResult
-      statement_with_retry &.exec(args)
+    def exec(*, args : Array) : ExecResult
+      statement_with_retry &.exec(args: args)
     end
 
     # See `QueryMethods#query`
@@ -35,8 +35,8 @@ module DB
     end
 
     # See `QueryMethods#query`
-    def query(args : Array) : ResultSet
-      statement_with_retry &.query(args)
+    def query(*, args : Array) : ResultSet
+      statement_with_retry &.query(args: args)
     end
 
     # See `QueryMethods#scalar`

--- a/src/db/pool_statement.cr
+++ b/src/db/pool_statement.cr
@@ -30,8 +30,8 @@ module DB
     end
 
     # See `QueryMethods#scalar`
-    def scalar(*args)
-      statement_with_retry &.scalar(*args)
+    def scalar(*args_, args : Array? = nil)
+      statement_with_retry &.scalar(*args_, args: args)
     end
 
     # builds a statement over a real connection

--- a/src/db/pool_statement.cr
+++ b/src/db/pool_statement.cr
@@ -15,13 +15,8 @@ module DB
     end
 
     # See `QueryMethods#exec`
-    def exec(*args) : ExecResult
-      statement_with_retry &.exec(*args)
-    end
-
-    # See `QueryMethods#exec`
-    def exec(*, args : Array) : ExecResult
-      statement_with_retry &.exec(args: args)
+    def exec(*t_args, args : Array? = nil) : ExecResult
+      statement_with_retry &.exec(*t_args, args: args)
     end
 
     # See `QueryMethods#query`
@@ -30,13 +25,8 @@ module DB
     end
 
     # See `QueryMethods#query`
-    def query(*args) : ResultSet
-      statement_with_retry &.query(*args)
-    end
-
-    # See `QueryMethods#query`
-    def query(*, args : Array) : ResultSet
-      statement_with_retry &.query(args: args)
+    def query(*t_args, args : Array? = nil) : ResultSet
+      statement_with_retry &.query(*t_args, args: args)
     end
 
     # See `QueryMethods#scalar`

--- a/src/db/pool_statement.cr
+++ b/src/db/pool_statement.cr
@@ -15,8 +15,8 @@ module DB
     end
 
     # See `QueryMethods#exec`
-    def exec(*t_args, args : Array? = nil) : ExecResult
-      statement_with_retry &.exec(*t_args, args: args)
+    def exec(*args_, args : Array? = nil) : ExecResult
+      statement_with_retry &.exec(*args_, args: args)
     end
 
     # See `QueryMethods#query`
@@ -25,8 +25,8 @@ module DB
     end
 
     # See `QueryMethods#query`
-    def query(*t_args, args : Array? = nil) : ResultSet
-      statement_with_retry &.query(*t_args, args: args)
+    def query(*args_, args : Array? = nil) : ResultSet
+      statement_with_retry &.query(*args_, args: args)
     end
 
     # See `QueryMethods#scalar`

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -42,8 +42,8 @@ module DB
     # result = db.query "select name from contacts where id = ?", args: [10]
     # ```
     #
-    def query(query, *t_args, args : Array? = nil)
-      build(query).query(*t_args, args: args)
+    def query(query, *args_, args : Array? = nil)
+      build(query).query(*args_, args: args)
     end
 
     # Executes a *query* and yields a `ResultSet` with the results.
@@ -56,9 +56,9 @@ module DB
     #   end
     # end
     # ```
-    def query(query, *t_args, args : Array? = nil)
+    def query(query, *args_, args : Array? = nil)
       # CHECK build(query).query(*args, &block)
-      rs = query(query, *t_args, args: args)
+      rs = query(query, *args_, args: args)
       yield rs ensure rs.close
     end
 
@@ -72,8 +72,8 @@ module DB
     # ```
     # name = db.query_one "select name from contacts where id = ?", 18, &.read(String)
     # ```
-    def query_one(query, *t_args, args : Array? = nil, &block : ResultSet -> U) : U forall U
-      query(query, *t_args, args: args) do |rs|
+    def query_one(query, *args_, args : Array? = nil, &block : ResultSet -> U) : U forall U
+      query(query, *args_, args: args) do |rs|
         raise DB::Error.new("no rows") unless rs.move_next
 
         value = yield rs
@@ -90,8 +90,8 @@ module DB
     # ```
     # db.query_one "select name, age from contacts where id = ?", 1, as: {String, Int32}
     # ```
-    def query_one(query, *t_args, args : Array? = nil, as types : Tuple)
-      query_one(query, *t_args, args: args) do |rs|
+    def query_one(query, *args_, args : Array? = nil, as types : Tuple)
+      query_one(query, *args_, args: args) do |rs|
         rs.read(*types)
       end
     end
@@ -105,8 +105,8 @@ module DB
     # ```
     # db.query_one "select name, age from contacts where id = ?", 1, as: {name: String, age: Int32}
     # ```
-    def query_one(query, *t_args, args : Array? = nil, as types : NamedTuple)
-      query_one(query, *t_args, args: args) do |rs|
+    def query_one(query, *args_, args : Array? = nil, as types : NamedTuple)
+      query_one(query, *args_, args: args) do |rs|
         rs.read(**types)
       end
     end
@@ -119,8 +119,8 @@ module DB
     # ```
     # db.query_one "select name from contacts where id = ?", 1, as: String
     # ```
-    def query_one(query, *t_args, args : Array? = nil, as type : Class)
-      query_one(query, *t_args, args: args) do |rs|
+    def query_one(query, *args_, args : Array? = nil, as type : Class)
+      query_one(query, *args_, args: args) do |rs|
         rs.read(type)
       end
     end
@@ -137,8 +137,8 @@ module DB
     # name = db.query_one? "select name from contacts where id = ?", 18, &.read(String)
     # typeof(name) # => String | Nil
     # ```
-    def query_one?(query, *t_args, args : Array? = nil, &block : ResultSet -> U) : U? forall U
-      query(query, *t_args, args: args) do |rs|
+    def query_one?(query, *args_, args : Array? = nil, &block : ResultSet -> U) : U? forall U
+      query(query, *args_, args: args) do |rs|
         return nil unless rs.move_next
 
         value = yield rs
@@ -158,8 +158,8 @@ module DB
     # result = db.query_one? "select name, age from contacts where id = ?", 1, as: {String, Int32}
     # typeof(result) # => Tuple(String, Int32) | Nil
     # ```
-    def query_one?(query, *t_args, args : Array? = nil, as types : Tuple)
-      query_one?(query, *t_args, args: args) do |rs|
+    def query_one?(query, *args_, args : Array? = nil, as types : Tuple)
+      query_one?(query, *args_, args: args) do |rs|
         rs.read(*types)
       end
     end
@@ -176,8 +176,8 @@ module DB
     # result = db.query_one? "select name, age from contacts where id = ?", 1, as: {age: String, name: Int32}
     # typeof(result) # => NamedTuple(age: String, name: Int32) | Nil
     # ```
-    def query_one?(query, *t_args, args : Array? = nil, as types : NamedTuple)
-      query_one?(query, *t_args, args: args) do |rs|
+    def query_one?(query, *args_, args : Array? = nil, as types : NamedTuple)
+      query_one?(query, *args_, args: args) do |rs|
         rs.read(**types)
       end
     end
@@ -193,8 +193,8 @@ module DB
     # name = db.query_one? "select name from contacts where id = ?", 1, as: String
     # typeof(name) # => String?
     # ```
-    def query_one?(query, *t_args, args : Array? = nil, as type : Class)
-      query_one?(query, *t_args, args: args) do |rs|
+    def query_one?(query, *args_, args : Array? = nil, as type : Class)
+      query_one?(query, *args_, args: args) do |rs|
         rs.read(type)
       end
     end
@@ -205,9 +205,9 @@ module DB
     # ```
     # names = db.query_all "select name from contacts", &.read(String)
     # ```
-    def query_all(query, *t_args, args : Array? = nil, &block : ResultSet -> U) : Array(U) forall U
+    def query_all(query, *args_, args : Array? = nil, &block : ResultSet -> U) : Array(U) forall U
       ary = [] of U
-      query_each(query, *t_args, args: args) do |rs|
+      query_each(query, *args_, args: args) do |rs|
         ary.push(yield rs)
       end
       ary
@@ -219,8 +219,8 @@ module DB
     # ```
     # contacts = db.query_all "select name, age from contacts", as: {String, Int32}
     # ```
-    def query_all(query, *t_args, args : Array? = nil, as types : Tuple)
-      query_all(query, *t_args, args: args) do |rs|
+    def query_all(query, *args_, args : Array? = nil, as types : Tuple)
+      query_all(query, *args_, args: args) do |rs|
         rs.read(*types)
       end
     end
@@ -232,8 +232,8 @@ module DB
     # ```
     # contacts = db.query_all "select name, age from contacts", as: {name: String, age: Int32}
     # ```
-    def query_all(query, *t_args, args : Array? = nil, as types : NamedTuple)
-      query_all(query, *t_args, args: args) do |rs|
+    def query_all(query, *args_, args : Array? = nil, as types : NamedTuple)
+      query_all(query, *args_, args: args) do |rs|
         rs.read(**types)
       end
     end
@@ -244,8 +244,8 @@ module DB
     # ```
     # names = db.query_all "select name from contacts", as: String
     # ```
-    def query_all(query, *t_args, args : Array? = nil, as type : Class)
-      query_all(query, *t_args, args: args) do |rs|
+    def query_all(query, *args_, args : Array? = nil, as type : Class)
+      query_all(query, *args_, args: args) do |rs|
         rs.read(type)
       end
     end
@@ -258,8 +258,8 @@ module DB
     #   puts rs.read(String)
     # end
     # ```
-    def query_each(query, *t_args, args : Array? = nil)
-      query(query, *t_args, args: args) do |rs|
+    def query_each(query, *args_, args : Array? = nil)
+      query(query, *args_, args: args) do |rs|
         rs.each do
           yield rs
         end
@@ -267,8 +267,8 @@ module DB
     end
 
     # Performs the `query` and returns an `ExecResult`
-    def exec(query, *t_args, args : Array? = nil)
-      build(query).exec(*t_args, args: args)
+    def exec(query, *args_, args : Array? = nil)
+      build(query).exec(*args_, args: args)
     end
 
     # Performs the `query` and returns a single scalar value
@@ -276,8 +276,8 @@ module DB
     # ```
     # puts db.scalar("SELECT MAX(name)").as(String) # => (a String)
     # ```
-    def scalar(query, *t_args, args : Array? = nil)
-      build(query).scalar(*t_args, args: args)
+    def scalar(query, *args_, args : Array? = nil)
+      build(query).scalar(*args_, args: args)
     end
   end
 end

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -271,5 +271,256 @@ module DB
     def scalar(query, *args)
       build(query).scalar(*args)
     end
+
+    # Executes a *query* and returns a `ResultSet` with the results.
+    # The `ResultSet` must be closed manually.
+    #
+    # ```
+    # result = db.query "select name from contacts where id = ?", 10
+    # begin
+    #   if result.move_next
+    #     id = result.read(Int32)
+    #   end
+    # ensure
+    #   result.close
+    # end
+    # ```
+    def query(query, *, args : Array)
+      build(query).query(args: args)
+    end
+
+    # Executes a *query* and yields a `ResultSet` with the results.
+    # The `ResultSet` is closed automatically.
+    #
+    # ```
+    # db.query("select name from contacts where age > ?", 18) do |rs|
+    #   rs.each do
+    #     name = rs.read(String)
+    #   end
+    # end
+    # ```
+    def query(query, *, args : Array)
+      # CHECK build(query).query(args: args, &block)
+      rs = query(query, args: args)
+      yield rs ensure rs.close
+    end
+
+    # Executes a *query* that expects a single row and yields a `ResultSet`
+    # positioned at that first row.
+    #
+    # The given block must not invoke `move_next` on the yielded result set.
+    #
+    # Raises `DB::Error` if there were no rows, or if there were more than one row.
+    #
+    # ```
+    # name = db.query_one "select name from contacts where id = ?", 18, &.read(String)
+    # ```
+    def query_one(query, *, args : Array, &block : ResultSet -> U) : U forall U
+      query(query, args: args) do |rs|
+        raise DB::Error.new("no rows") unless rs.move_next
+
+        value = yield rs
+        raise DB::Error.new("more than one row") if rs.move_next
+        return value
+      end
+    end
+
+    # Executes a *query* that expects a single row and returns it
+    # as a tuple of the given *types*.
+    #
+    # Raises `DB::Error` if there were no rows, or if there were more than one row.
+    #
+    # ```
+    # db.query_one "select name, age from contacts where id = ?", 1, as: {String, Int32}
+    # ```
+    def query_one(query, *, args : Array, as types : Tuple)
+      query_one(query, args: args) do |rs|
+        rs.read(*types)
+      end
+    end
+
+    # Executes a *query* that expects a single row and returns it
+    # as a named tuple of the given *types* (the keys of the named tuple
+    # are not necessarily the column names).
+    #
+    # Raises `DB::Error` if there were no rows, or if there were more than one row.
+    #
+    # ```
+    # db.query_one "select name, age from contacts where id = ?", 1, as: {name: String, age: Int32}
+    # ```
+    def query_one(query, *, args : Array, as types : NamedTuple)
+      query_one(query, args: args) do |rs|
+        rs.read(**types)
+      end
+    end
+
+    # Executes a *query* that expects a single row
+    # and returns the first column's value as the given *type*.
+    #
+    # Raises `DB::Error` if there were no rows, or if there were more than one row.
+    #
+    # ```
+    # db.query_one "select name from contacts where id = ?", 1, as: String
+    # ```
+    def query_one(query, *, args : Array, as type : Class)
+      query_one(query, args: args) do |rs|
+        rs.read(type)
+      end
+    end
+
+    # Executes a *query* that expects at most a single row and yields a `ResultSet`
+    # positioned at that first row.
+    #
+    # Returns `nil`, not invoking the block, if there were no rows.
+    #
+    # Raises `DB::Error` if there were more than one row
+    # (this ends up invoking the block once).
+    #
+    # ```
+    # name = db.query_one? "select name from contacts where id = ?", 18, &.read(String)
+    # typeof(name) # => String | Nil
+    # ```
+    def query_one?(query, *, args : Array, &block : ResultSet -> U) : U? forall U
+      query(query, args: args) do |rs|
+        return nil unless rs.move_next
+
+        value = yield rs
+        raise DB::Error.new("more than one row") if rs.move_next
+        return value
+      end
+    end
+
+    # Executes a *query* that expects a single row and returns it
+    # as a tuple of the given *types*.
+    #
+    # Returns `nil` if there were no rows.
+    #
+    # Raises `DB::Error` if there were more than one row.
+    #
+    # ```
+    # result = db.query_one? "select name, age from contacts where id = ?", 1, as: {String, Int32}
+    # typeof(result) # => Tuple(String, Int32) | Nil
+    # ```
+    def query_one?(query, *, args : Array, as types : Tuple)
+      query_one?(query, args: args) do |rs|
+        rs.read(*types)
+      end
+    end
+
+    # Executes a *query* that expects a single row and returns it
+    # as a named tuple of the given *types* (the keys of the named tuple
+    # are not necessarily the column names).
+    #
+    # Returns `nil` if there were no rows.
+    #
+    # Raises `DB::Error` if there were more than one row.
+    #
+    # ```
+    # result = db.query_one? "select name, age from contacts where id = ?", 1, as: {age: String, name: Int32}
+    # typeof(result) # => NamedTuple(age: String, name: Int32) | Nil
+    # ```
+    def query_one?(query, *, args : Array, as types : NamedTuple)
+      query_one?(query, args: args) do |rs|
+        rs.read(**types)
+      end
+    end
+
+    # Executes a *query* that expects a single row
+    # and returns the first column's value as the given *type*.
+    #
+    # Returns `nil` if there were no rows.
+    #
+    # Raises `DB::Error` if there were more than one row.
+    #
+    # ```
+    # name = db.query_one? "select name from contacts where id = ?", 1, as: String
+    # typeof(name) # => String?
+    # ```
+    def query_one?(query, *, args : Array, as type : Class)
+      query_one?(query, args: args) do |rs|
+        rs.read(type)
+      end
+    end
+
+    # Executes a *query* and yield a `ResultSet` positioned at the beginning
+    # of each row, returning an array of the values of the blocks.
+    #
+    # ```
+    # names = db.query_all "select name from contacts", &.read(String)
+    # ```
+    def query_all(query, *, args : Array, &block : ResultSet -> U) : Array(U) forall U
+      ary = [] of U
+      query_each(query, args: args) do |rs|
+        ary.push(yield rs)
+      end
+      ary
+    end
+
+    # Executes a *query* and returns an array where each row is
+    # read as a tuple of the given *types*.
+    #
+    # ```
+    # contacts = db.query_all "select name, age from contacts", as: {String, Int32}
+    # ```
+    def query_all(query, *, args : Array, as types : Tuple)
+      query_all(query, args: args) do |rs|
+        rs.read(*types)
+      end
+    end
+
+    # Executes a *query* and returns an array where each row is
+    # read as a named tuple of the given *types* (the keys of the named tuple
+    # are not necessarily the column names).
+    #
+    # ```
+    # contacts = db.query_all "select name, age from contacts", as: {name: String, age: Int32}
+    # ```
+    def query_all(query, *, args : Array, as types : NamedTuple)
+      query_all(query, args: args) do |rs|
+        rs.read(**types)
+      end
+    end
+
+    # Executes a *query* and returns an array where the
+    # value of each row is read as the given *type*.
+    #
+    # ```
+    # names = db.query_all "select name from contacts", as: String
+    # ```
+    def query_all(query, *, args : Array, as type : Class)
+      query_all(query, args: args) do |rs|
+        rs.read(type)
+      end
+    end
+
+    # Executes a *query* and yields the `ResultSet` once per each row.
+    # The `ResultSet` is closed automatically.
+    #
+    # ```
+    # db.query_each "select name from contacts" do |rs|
+    #   puts rs.read(String)
+    # end
+    # ```
+    def query_each(query, *, args : Array)
+      query(query, args: args) do |rs|
+        rs.each do
+          yield rs
+        end
+      end
+    end
+
+    # Performs the `query` and returns an `ExecResult`
+    def exec(query, *, args : Array)
+      build(query).exec(args: args)
+    end
+
+    # Performs the `query` and returns a single scalar value
+    #
+    # ```
+    # puts db.scalar("SELECT MAX(name)").as(String) # => (a String)
+    # ```
+    def scalar(query, *, args : Array)
+      build(query).scalar(args: args)
+    end
   end
 end

--- a/src/db/statement.cr
+++ b/src/db/statement.cr
@@ -65,7 +65,7 @@ module DB
 
     # See `QueryMethods#exec`
     def exec(*t_args, args : Array? = nil) : DB::ExecResult
-      perform_exec_and_release(args || t_args)
+      perform_exec_and_release(EnumerableConcat.build(t_args, args))
     end
 
     # See `QueryMethods#query`
@@ -75,7 +75,7 @@ module DB
 
     # See `QueryMethods#query`
     def query(*t_args, args : Array? = nil) : DB::ResultSet
-      perform_query_with_rescue(args || t_args)
+      perform_query_with_rescue(EnumerableConcat.build(t_args, args))
     end
 
     private def perform_exec_and_release(args : Enumerable) : ExecResult

--- a/src/db/statement.cr
+++ b/src/db/statement.cr
@@ -8,8 +8,8 @@ module DB
     end
 
     # See `QueryMethods#scalar`
-    def scalar(*args)
-      query(*args) do |rs|
+    def scalar(*t_args, args : Array? = nil)
+      query(*t_args, args: args) do |rs|
         rs.each do
           return rs.read
         end
@@ -19,24 +19,20 @@ module DB
     end
 
     # See `QueryMethods#query`
-    def query(*args)
-      rs = query(*args)
+    def query(*t_args, args : Array? = nil)
+      rs = query(*t_args, args: args)
       yield rs ensure rs.close
     end
 
     # See `QueryMethods#exec`
     abstract def exec : ExecResult
     # See `QueryMethods#exec`
-    abstract def exec(*args) : ExecResult
-    # See `QueryMethods#exec`
-    abstract def exec(*, args : Array) : ExecResult
+    abstract def exec(*t_args, args : Array? = nil) : ExecResult
 
     # See `QueryMethods#query`
     abstract def query : ResultSet
     # See `QueryMethods#query`
-    abstract def query(*args) : ResultSet
-    # See `QueryMethods#query`
-    abstract def query(*, args : Array) : ResultSet
+    abstract def query(*t_args, args : Array? = nil) : ResultSet
   end
 
   # Represents a query in a `Connection`.
@@ -68,14 +64,8 @@ module DB
     end
 
     # See `QueryMethods#exec`
-    def exec(*, args : Array) : DB::ExecResult
-      perform_exec_and_release(args)
-    end
-
-    # See `QueryMethods#exec`
-    def exec(*args)
-      # TODO better way to do it
-      perform_exec_and_release(args)
+    def exec(*t_args, args : Array? = nil) : DB::ExecResult
+      perform_exec_and_release(args || t_args)
     end
 
     # See `QueryMethods#query`
@@ -84,13 +74,8 @@ module DB
     end
 
     # See `QueryMethods#query`
-    def query(*, args : Array) : DB::ResultSet
-      perform_query_with_rescue args
-    end
-
-    # See `QueryMethods#query`
-    def query(*args)
-      perform_query_with_rescue args
+    def query(*t_args, args : Array? = nil) : DB::ResultSet
+      perform_query_with_rescue(args || t_args)
     end
 
     private def perform_exec_and_release(args : Enumerable) : ExecResult

--- a/src/db/statement.cr
+++ b/src/db/statement.cr
@@ -8,8 +8,8 @@ module DB
     end
 
     # See `QueryMethods#scalar`
-    def scalar(*t_args, args : Array? = nil)
-      query(*t_args, args: args) do |rs|
+    def scalar(*args_, args : Array? = nil)
+      query(*args_, args: args) do |rs|
         rs.each do
           return rs.read
         end
@@ -19,20 +19,20 @@ module DB
     end
 
     # See `QueryMethods#query`
-    def query(*t_args, args : Array? = nil)
-      rs = query(*t_args, args: args)
+    def query(*args_, args : Array? = nil)
+      rs = query(*args_, args: args)
       yield rs ensure rs.close
     end
 
     # See `QueryMethods#exec`
     abstract def exec : ExecResult
     # See `QueryMethods#exec`
-    abstract def exec(*t_args, args : Array? = nil) : ExecResult
+    abstract def exec(*args_, args : Array? = nil) : ExecResult
 
     # See `QueryMethods#query`
     abstract def query : ResultSet
     # See `QueryMethods#query`
-    abstract def query(*t_args, args : Array? = nil) : ResultSet
+    abstract def query(*args_, args : Array? = nil) : ResultSet
   end
 
   # Represents a query in a `Connection`.
@@ -64,8 +64,8 @@ module DB
     end
 
     # See `QueryMethods#exec`
-    def exec(*t_args, args : Array? = nil) : DB::ExecResult
-      perform_exec_and_release(EnumerableConcat.build(t_args, args))
+    def exec(*args_, args : Array? = nil) : DB::ExecResult
+      perform_exec_and_release(EnumerableConcat.build(args_, args))
     end
 
     # See `QueryMethods#query`
@@ -74,8 +74,8 @@ module DB
     end
 
     # See `QueryMethods#query`
-    def query(*t_args, args : Array? = nil) : DB::ResultSet
-      perform_query_with_rescue(EnumerableConcat.build(t_args, args))
+    def query(*args_, args : Array? = nil) : DB::ResultSet
+      perform_query_with_rescue(EnumerableConcat.build(args_, args))
     end
 
     private def perform_exec_and_release(args : Enumerable) : ExecResult

--- a/src/db/statement.cr
+++ b/src/db/statement.cr
@@ -29,14 +29,14 @@ module DB
     # See `QueryMethods#exec`
     abstract def exec(*args) : ExecResult
     # See `QueryMethods#exec`
-    abstract def exec(args : Array) : ExecResult
+    abstract def exec(*, args : Array) : ExecResult
 
     # See `QueryMethods#query`
     abstract def query : ResultSet
     # See `QueryMethods#query`
     abstract def query(*args) : ResultSet
     # See `QueryMethods#query`
-    abstract def query(args : Array) : ResultSet
+    abstract def query(*, args : Array) : ResultSet
   end
 
   # Represents a query in a `Connection`.
@@ -68,7 +68,7 @@ module DB
     end
 
     # See `QueryMethods#exec`
-    def exec(args : Array) : DB::ExecResult
+    def exec(*, args : Array) : DB::ExecResult
       perform_exec_and_release(args)
     end
 
@@ -84,7 +84,7 @@ module DB
     end
 
     # See `QueryMethods#query`
-    def query(args : Array) : DB::ResultSet
+    def query(*, args : Array) : DB::ResultSet
       perform_query_with_rescue args
     end
 

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -154,7 +154,7 @@ module DB
         end
 
         it "executes with bind #{value_desc} as array" do |db|
-          db.scalar(select_scalar(param(1), sql_type), [value]).should eq(value)
+          db.scalar(select_scalar(param(1), sql_type), args: [value]).should eq(value)
         end
 
         it "select #{value_desc} as literal" do |db|


### PR DESCRIPTION
This change allows to use an array as single argument for #exec and
 #query methods. Before it was shadowed by the *args splat overload.

Fixes #100