### PR TITLE
Remove call to obsolete Spec.matches?

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -123,7 +123,6 @@ module DB
     getter its = [] of SpecIt
 
     def it(description = "assert", prepared = :default, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block : DB::Database ->)
-      return unless Spec.matches?(description, file, line, end_line)
       @its << SpecIt.new(description, prepared, file, line, end_line, block)
     end
 


### PR DESCRIPTION
It was an optimization but it does not work (and is not needed) since the changes in spec for Crystal 0.31