### PR TITLE
making exception error string a proper error class.

### DIFF
--- a/spec/statement_spec.cr
+++ b/spec/statement_spec.cr
@@ -208,4 +208,13 @@ describe DB::Statement do
       db.pool.is_available?(DummyDriver::DummyConnection.connections.first)
     end
   end
+
+  it "raises NoResultsError for scalar" do
+    with_dummy_connection do |cnn|
+      stmt = cnn.prepared ""
+      expect_raises DB::NoResultsError do
+        stmt.scalar "SELECT LIMIT 0"
+      end
+    end
+  end
 end

--- a/src/db/error.cr
+++ b/src/db/error.cr
@@ -29,4 +29,8 @@ module DB
 
   class Rollback < Error
   end
+
+  # Raised when a scalar query returns no results.
+  class NoResultsError < Error
+  end
 end

--- a/src/db/statement.cr
+++ b/src/db/statement.cr
@@ -15,7 +15,7 @@ module DB
         end
       end
 
-      raise "no results"
+      raise NoResultsError.new("no results")
     end
 
     # See `QueryMethods#query`


### PR DESCRIPTION
Fixes #120

I was going to write a spec for it, but the specs in this are sort of complicated, and I wasn't sure how to test that the scalar raises an exception. 