### PR TITLE
Fix mutex deadlock in setup_connection

### DIFF
--- a/spec/database_spec.cr
+++ b/spec/database_spec.cr
@@ -8,6 +8,7 @@ describe DB::Database do
 
       db.setup_connection do |cnn|
         cnn_setup += 1
+        cnn.scalar("1").should eq "1"
       end
 
       cnn_setup.should eq(2)

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -55,6 +55,7 @@ module DB
       @pool = uninitialized Pool(Connection) # in order to use self in the factory proc
       @pool = Pool.new(**pool_options) {
         conn = @driver.build_connection(self).as(Connection)
+        conn.auto_release = false
         @setup_connection.call conn
         conn
       }


### PR DESCRIPTION
Adds auto_release = false in setup_connection to avoid trying to release
the connection to the pool before it has been added.

Fixes #127