### PR TITLE
Improve DB::MappingException usage

### DIFF
--- a/spec/serializable_spec.cr
+++ b/spec/serializable_spec.cr
@@ -105,19 +105,19 @@ describe "DB::Serializable" do
   end
 
   it "should fail to initialize a simple model if types do not match" do
-    expect_raises ArgumentError do
+    expect_raises DB::MappingException, "Invalid Int32: b\n  deserializing SimpleModel#c0" do
       from_dummy("b,a", SimpleModel)
     end
   end
 
   it "should fail to initialize a simple model if there is a missing column" do
-    expect_raises DB::MappingException do
+    expect_raises DB::MappingException, "Missing column c1\n  deserializing SimpleModel#c1" do
       from_dummy("1", SimpleModel)
     end
   end
 
   it "should fail to initialize a simple model if there is an unexpected column" do
-    expect_raises DB::MappingException do
+    expect_raises DB::MappingException, "Unknown column: c2\n  deserializing SimpleModel" do
       from_dummy("1,a,b", SimpleModel)
     end
   end

--- a/src/db/error.cr
+++ b/src/db/error.cr
@@ -3,6 +3,19 @@ module DB
   end
 
   class MappingException < Error
+    getter klass
+    getter property
+
+    def initialize(message, @klass : String, @property : String? = nil, cause : Exception? = nil)
+      message = String.build do |io|
+        io << message
+        io << "\n  deserializing " << @klass
+        if property = @property
+          io << "#" << property
+        end
+      end
+      super(message, cause: cause)
+    end
   end
 
   class PoolTimeout < Error

--- a/src/db/mapping.cr
+++ b/src/db/mapping.cr
@@ -117,7 +117,7 @@ module DB
           {% end %}
           else
             {% if strict %}
-              raise ::DB::MappingException.new("unknown result set attribute: #{col_name}")
+              raise ::DB::MappingException.new("unknown result set attribute: #{col_name}", self.class.to_s)
             {% else %}
               %rs.read
             {% end %}
@@ -127,7 +127,7 @@ module DB
       {% for key, value in properties %}
         {% unless value[:nilable] || value[:default] != nil %}
           if %var{key.id}.is_a?(Nil) && !%found{key.id}
-            raise ::DB::MappingException.new("missing result set attribute: {{(value[:key] || key).id}}")
+            raise ::DB::MappingException.new("missing result set attribute: {{(value[:key] || key).id}}", self.class.to_s)
           end
         {% end %}
       {% end %}


### PR DESCRIPTION
This adds more locations where DB::MappingException is raised and it adds information about the type and property that failed to deserialize.

cf. https://github.com/crystal-lang/crystal/pull/9274