### PR TITLE
Add logging for executing queries

### DIFF
--- a/spec/custom_drivers_types_spec.cr
+++ b/spec/custom_drivers_types_spec.cr
@@ -48,11 +48,11 @@ class FooDriver < DB::Driver
   end
 
   class FooConnection < DB::Connection
-    def build_prepared_statement(query) : DB::Statement
-      FooStatement.new(self)
+    def build_prepared_statement(command) : DB::Statement
+      FooStatement.new(self, command)
     end
 
-    def build_unprepared_statement(query) : DB::Statement
+    def build_unprepared_statement(command) : DB::Statement
       raise "not implemented"
     end
   end
@@ -112,7 +112,7 @@ class BarDriver < DB::Driver
 
   class BarConnection < DB::Connection
     def build_prepared_statement(query) : DB::Statement
-      BarStatement.new(self)
+      BarStatement.new(self, query)
     end
 
     def build_unprepared_statement(query) : DB::Statement

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -96,22 +96,22 @@ class DummyDriver < DB::Driver
   class DummyStatement < DB::Statement
     property params
 
-    def initialize(connection, @query : String, @prepared : Bool)
+    def initialize(connection, command : String, @prepared : Bool)
       @params = Hash(Int32 | String, DB::Any | Array(DB::Any)).new
-      super(connection)
-      raise DB::Error.new(query) if query == "syntax error"
+      super(connection, command)
+      raise DB::Error.new(command) if command == "syntax error"
     end
 
     protected def perform_query(args : Enumerable) : DB::ResultSet
       @connection.as(DummyConnection).check
       set_params args
-      DummyResultSet.new self, @query
+      DummyResultSet.new self, command
     end
 
     protected def perform_exec(args : Enumerable) : DB::ExecResult
       @connection.as(DummyConnection).check
       set_params args
-      raise DB::Error.new("forced exception due to query") if @query == "raise"
+      raise DB::Error.new("forced exception due to query") if command == "raise"
       DB::ExecResult.new 0i64, 0_i64
     end
 
@@ -149,9 +149,9 @@ class DummyDriver < DB::Driver
 
     @@last_result_set : self?
 
-    def initialize(statement, query)
+    def initialize(statement, command)
       super(statement)
-      @top_values = query.split.map { |r| r.split(',') }.to_a
+      @top_values = command.split.map { |r| r.split(',') }.to_a
       @column_count = @top_values.size > 0 ? @top_values[0].size : 2
 
       @@last_result_set = self

--- a/src/db.cr
+++ b/src/db.cr
@@ -137,7 +137,7 @@ module DB
     build_connection(uri)
   end
 
-  # ditto
+  # :ditto:
   def self.connect(uri : URI | String, &block)
     cnn = build_connection(uri)
     begin

--- a/src/db.cr
+++ b/src/db.cr
@@ -1,4 +1,5 @@
 require "uri"
+require "log"
 
 # The DB module is a unified interface for database access.
 # Individual database systems are supported by specific database driver shards.
@@ -75,6 +76,8 @@ require "uri"
 # ```
 #
 module DB
+  Log = ::Log.for(self)
+
   # Types supported to interface with database driver.
   # These can be used in any `ResultSet#read` or any `Database#query` related
   # method to be used as query parameters

--- a/src/db/enumerable_concat.cr
+++ b/src/db/enumerable_concat.cr
@@ -20,7 +20,7 @@ module DB
     end
 
     # returns given `e1 : T` an `Enumerable(T')` and `e2 : U` an `Enumerable(U') | Nil`
-    # it returns and `Enumerable(T' | U')` that enumerates the elements of `e1`
+    # it returns an `Enumerable(T' | U')` that enumerates the elements of `e1`
     # and, later, the elements of `e2`.
     def self.build(e1 : T, e2 : U)
       return e1 if e2.nil? || e2.empty?

--- a/src/db/enumerable_concat.cr
+++ b/src/db/enumerable_concat.cr
@@ -20,7 +20,7 @@ module DB
     end
 
     # returns given `e1 : T` an `Enumerable(T')` and `e2 : U` an `Enumerable(U') | Nil`
-    # it retuns and `Enumerable(T' | U')` that enumerates the elements of `e1`
+    # it returns and `Enumerable(T' | U')` that enumerates the elements of `e1`
     # and, later, the elements of `e2`.
     def self.build(e1 : T, e2 : U)
       return e1 if e2.nil? || e2.empty?

--- a/src/db/statement.cr
+++ b/src/db/statement.cr
@@ -51,7 +51,9 @@ module DB
     # :nodoc:
     getter connection
 
-    def initialize(@connection : Connection)
+    getter command : String
+
+    def initialize(@connection : Connection, @command : String)
     end
 
     def release_connection
@@ -79,21 +81,57 @@ module DB
     end
 
     private def perform_exec_and_release(args : Enumerable) : ExecResult
+      before_query_or_exec(args)
       return perform_exec(args)
     ensure
+      after_query_or_exec(args)
       release_connection
     end
 
     private def perform_query_with_rescue(args : Enumerable) : ResultSet
+      before_query_or_exec(args)
       return perform_query(args)
     rescue e : Exception
       # Release connection only when an exception occurs during the query
       # execution since we need the connection open while the ResultSet is open
       release_connection
       raise e
+    ensure
+      after_query_or_exec(args)
     end
 
     protected abstract def perform_query(args : Enumerable) : ResultSet
     protected abstract def perform_exec(args : Enumerable) : ExecResult
+
+    protected def before_query_or_exec(args : Enumerable)
+      emit_log(args)
+    end
+
+    protected def after_query_or_exec(args : Enumerable)
+    end
+
+    protected def emit_log(args : Enumerable)
+      Log.debug &.emit("Executing query", query: command, args: arg_to_log(args))
+    end
+
+    private def arg_to_log(arg) : ::Log::Metadata::Value
+      ::Log::Metadata::Value.new(arg.to_s)
+    end
+
+    private def arg_to_log(arg : Enumerable) : ::Log::Metadata::Value
+      ::Log::Metadata::Value.new(arg.to_a.map { |a| arg_to_log(a).as(::Log::Metadata::Value) })
+    end
+
+    private def arg_to_log(arg : Int) : ::Log::Metadata::Value
+      ::Log::Metadata::Value.new(arg.to_i64)
+    end
+
+    private def arg_to_log(arg : UInt64) : ::Log::Metadata::Value
+      ::Log::Metadata::Value.new(arg.to_s)
+    end
+
+    private def arg_to_log(arg : Nil | Bool | Int32 | Int64 | Float32 | Float64 | String | Time) : ::Log::Metadata::Value
+      ::Log::Metadata::Value.new(arg)
+    end
   end
 end


### PR DESCRIPTION
This PR adds a debug "Executing query" message to the `db` log source. The query and the arguments are passed as local metadata `query` and `args.

The arguments are translated to `Log::Metadata::Value` via `DB::Statement#arg_to_log` method.

For example in crystal-pg the following code would allow customizing how the `Geo::Point` argument is translated.

```crystal
class DB::Statement
  private def arg_to_log(arg : PG::Geo::Point)
    Log::Metadata::Value.new("(#{arg.x}, #{arg.y})::point")
  end
end
```

By default, `arg.to_s` is used for all the values that are not directly supported by `Log::Metadata::Value`.

`DB::Statement#before_query_or_exec` & `after_query_or_exec` protected methods can be used to hook around the statement execution.

The `DB::Statement` has now a `command : String` property that is specified during initialization. This the breaking-change part of this PR.


Fixes #62
Closes #64



