### PR TITLE
Add docs for DB::Database#setup_connection

### DIFF
--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -61,6 +61,15 @@ module DB
       }
     end
 
+    # Run the specified block every time a new connection is established, yielding the new connection
+    # to the block.
+    #
+    # ```
+    # db = DB.open(DB_URL)
+    # db.setup_connection do |connection|
+    #   connection.exec "SET TIME ZONE 'America/New_York'"
+    # end
+    # ```
     def setup_connection(&proc : Connection -> Nil)
       @setup_connection = proc
       @pool.each_resource do |conn|


### PR DESCRIPTION
Found out about this method in [this forum post](https://forum.crystal-lang.org/t/sqlite-and-concurrency/2639/3). It's something I didn't realize existed but that I've wanted a few times, so I figured I'd add some docs for it in case it helps people discover it. 🙂 