### PR TITLE
Fix model.from_rs argument type typo

### DIFF
--- a/src/db/serializable.cr
+++ b/src/db/serializable.cr
@@ -95,7 +95,7 @@ module DB
           super
         end
 
-        def self.from_rs(rs : ::DB::Result_set)
+        def self.from_rs(rs : ::DB::ResultSet)
           super
         end
       end


### PR DESCRIPTION
Fixed a typo of 

```crystal
def self.from_rs(rs : ::DB::Result_set)
```
->
```crystal
def self.from_rs(rs : ::DB::ResultSet)
```

- Resolves https://github.com/crystal-lang/crystal-db/issues/143
