### PR TITLE
Containerise crystal-db for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: crystal
+
+services:
+  - docker
+
 crystal:
   - latest
   - nightly
-script:
-  - crystal spec
-  - crystal tool format --check
+
+  script:
+  - docker build -t crystal_db . && docker run crystal_db

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ crystal:
   - latest
   - nightly
 
-  script:
+script:
   - docker build -t crystal_db . && docker run crystal_db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM crystallang/crystal:0.35.1-alpine
+WORKDIR /app
+
+COPY shard.yml /app
+RUN shards install
+
+COPY spec /app/spec
+COPY src /app/src
+
+RUN crystal tool format --check
+
+ENTRYPOINT ["crystal", "spec", "--error-trace", "-v"]


### PR DESCRIPTION
CI is reporting that specs fail on the master branch even though the latest commit was only a change to comments/ documentation, and not to the code, (https://github.com/crystal-lang/crystal-db/commit/eaddae7d71d52536453ea2d94777854f1b057f83) and consecutively before that CI was passing.

This suggested that environmental differences (OS) compromise the reproducibility of the test. To counter this, I thought it would be a good idea to containerise the test build for CI so this situation would not occur again.