### PR TITLE
feat(error): close resources on resource lost

### DIFF
--- a/src/db/error.cr
+++ b/src/db/error.cr
@@ -18,6 +18,7 @@ module DB
     getter resource : T
 
     def initialize(@resource : T)
+      @resource.close
     end
   end
 

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -182,7 +182,7 @@ module DB
           # if the connection is lost it will be closed by
           # the exception to release resources
           # we still need to remove it from the known pool.
-          # Closed connection will be evicted from statemetn cache
+          # Closed connection will be evicted from statement cache
           # in PoolPreparedStatement#clean_connections
           sync { delete(e.resource) }
         rescue e : PoolResourceRefused

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -179,10 +179,12 @@ module DB
           sleep @retry_delay if i >= current_available
           return yield
         rescue e : PoolResourceLost(T)
-          # if the connection is lost close it to release resources
-          # and remove it from the known pool.
+          # if the connection is lost it will be closed by
+          # the exception to release resources
+          # we still need to remove it from the known pool.
+          # Closed connection will be evicted from statemetn cache
+          # in PoolPreparedStatement#clean_connections
           sync { delete(e.resource) }
-          e.resource.close
         rescue e : PoolResourceRefused
           # a ConnectionRefused means a new connection
           # was intended to be created


### PR DESCRIPTION
this allows exceptions to be handled outside of the pool logic without risk of the resource being returned to the pool