### PR TITLE
Raise a specific class error instead of string literal

### DIFF
--- a/src/db/error.cr
+++ b/src/db/error.cr
@@ -46,4 +46,9 @@ module DB
   # Raised when a scalar query returns no results.
   class NoResultsError < Error
   end
+
+  # Raised when the type returned for the column value
+  # does not match the type expected.
+  class ColumnTypeMismatchError < Error
+  end
 end

--- a/src/db/result_set.cr
+++ b/src/db/result_set.cr
@@ -80,7 +80,7 @@ module DB
       if value.is_a?(T)
         value
       else
-        raise "#{self.class}#read returned a #{value.class}. A #{T} was expected."
+        raise DB::ColumnTypeMismatchError.new("#{self.class}#read returned a #{value.class}. A #{T} was expected.")
       end
     end
 


### PR DESCRIPTION
Related: #22 

I don't think it quite solves the original issue since a better solution would be to show *which* column didn't match; however, by adding a custom error class, this at least allows ORMs to catch this specific error to override as they need.

I wasn't quite sure how to test this with the dummy_driver, but if a spec is needed, I can add one in.