### PR TITLE
Add workaround for crystal-lang/crystal#9483

### DIFF
--- a/src/db/begin_transaction.cr
+++ b/src/db/begin_transaction.cr
@@ -13,7 +13,7 @@ module DB
     # can be called explicitly.
     # Returns the value of the block.
     def transaction(& : Transaction -> T) : T? forall T
-      # Cast to workaround crystal-lang/crystal#9483
+      # TODO: Cast to workaround crystal-lang/crystal#9483
       # begin_transaction returns a Tx where Tx < Transaction
       tx = begin_transaction.as(Transaction)
       begin

--- a/src/db/begin_transaction.cr
+++ b/src/db/begin_transaction.cr
@@ -13,7 +13,9 @@ module DB
     # can be called explicitly.
     # Returns the value of the block.
     def transaction(& : Transaction -> T) : T? forall T
-      tx = begin_transaction
+      # Cast to workaround crystal-lang/crystal#9483
+      # begin_transaction returns a Tx where Tx < Transaction
+      tx = begin_transaction.as(Transaction)
       begin
         res = yield tx
       rescue DB::Rollback


### PR DESCRIPTION
After merging #159 I found and issue when using it in the actual drivers.

Building the specs of them leads to a:

```
BUG: trying to downcast DB::Transaction+ <- DB::TopLevelTransaction (Exception)
  ...
```

This seems related to crystal-lang/crystal#9483 which is still open.
The workaround is a safe cast before yielding. The cast is safe because of the return type restriction of `begin_transaction : Transaction`.

Unfortunately there is no way to add a spec for this on crystal-db because `DummyDriver` is loaded in the specs. `DummyDriver` defines its own custom transaction type and that, somehow, make the compile error go away also. Drivers do not need to define their own transaction.

By using a `foo.cr` in the root of crystal-db you can reproduce the issue, as long as DummyDriver is not loaded.

```
require "./src/db"

DB.open "fake://host" do |db|
  db.transaction do |tx_0|
    tx_0.transaction do |tx_1|
      tx_1.transaction do |tx_2|
      end
    end
    tx_0.rollback
  end
end
```

Note: there is no FakeDriver defined, and that is fine for this snippet. I was not able to reduce it further.

```
% crystal foo.cr
BUG: trying to downcast DB::Transaction+ <- DB::TopLevelTransaction (Exception)
  from raise<Exception>:NoReturn
  from raise<String>:NoReturn
  from Crystal::CodeGenVisitor#downcast_distinct<LLVM::Value, Crystal::Type+, Crystal::Type+>:NoReturn
  from Crystal::CodeGenVisitor#downcast<LLVM::Value, Crystal::Type+, Crystal::Type+, Bool>:LLVM::Value
  from Crystal::CodeGenVisitor#visit<Crystal::Var+>:(LLVM::Value | Nil)
  from Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::CodeGenVisitor>:Nil
  from Crystal::CodeGenVisitor#visit<Crystal::Call>:Bool
  from Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::CodeGenVisitor>:Nil
```


