### PR TITLE
Fix specs for Crystal 1.4.0

### DIFF
--- a/spec/serializable_spec.cr
+++ b/spec/serializable_spec.cr
@@ -105,7 +105,7 @@ describe "DB::Serializable" do
   end
 
   it "should fail to initialize a simple model if types do not match" do
-    expect_raises DB::MappingException, "Invalid Int32: b\n  deserializing SimpleModel#c0" do
+    expect_raises DB::MappingException, /Invalid Int32: "?b"?\n  deserializing SimpleModel#c0/ do
       from_dummy("b,a", SimpleModel)
     end
   end


### PR DESCRIPTION
The format of string conversion error messages was changed in https://github.com/crystal-lang/crystal/pull/11883

See https://github.com/crystal-lang/crystal-db/runs/5622657297