### PR TITLE
Close a transaction when `return`ing from within its block

### DIFF
--- a/spec/transaction_spec.cr
+++ b/spec/transaction_spec.cr
@@ -95,6 +95,20 @@ describe DB::Transaction do
     t.committed.should be_false
   end
 
+  it "transaction with block from connection should be committed if `return` is called" do
+    t = uninitialized DummyDriver::DummyTransaction
+
+    with_witness do |w|
+      with_dummy_connection do |cnn|
+        t = return_from_txn(cnn).as(DummyDriver::DummyTransaction)
+        w.check
+      end
+    end
+
+    t.rolledback.should be_false
+    t.committed.should be_true
+  end
+
   it "transaction can be committed within block" do
     with_dummy_connection do |cnn|
       cnn.transaction do |tx|
@@ -209,5 +223,11 @@ describe DB::Transaction do
       res.should be_nil
       typeof(res).should eq(Int32 | Nil)
     end
+  end
+end
+
+private def return_from_txn(cnn)
+  cnn.transaction do |tx|
+    return tx
   end
 end


### PR DESCRIPTION
If you open a transaction inside a method and `return` from that method, the transaction remains open. Seems [this `else`](https://github.com/crystal-lang/crystal-db/blob/v0.11.0/src/db/begin_transaction.cr#L32-L35) doesn't get invoked on a `return`.

Reproduction:

```crystal
require "db"
require "pg"
require "log"

# To show that the transaction is never COMMITed nor ROLLBACKed
Log.setup :debug

pg = DB.open("postgres:///")

2.times { do_the_thing pg }

def do_the_thing(pg)
  pg.transaction do |txn|
    rs = txn.connection.exec "select 42"

    return
  end
end
```

To do this requires an `ensure` block, but that would also execute alongside every `rescue` and the `else`, so instead I just made the `rescue` blocks flip a bit and the `ensure` block does the work based on the state of that bit.