### PR TITLE
Allow the use of enums

### DIFF
--- a/spec/database_spec.cr
+++ b/spec/database_spec.cr
@@ -8,7 +8,7 @@ describe DB::Database do
 
       db.setup_connection do |cnn|
         cnn_setup += 1
-        cnn.scalar("1").should eq "1"
+        cnn.scalar("a").should eq "a"
       end
 
       cnn_setup.should eq(2)

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -187,7 +187,7 @@ class DummyDriver < DB::Driver
         return (@statement.as(DummyStatement)).params[0]
       end
 
-      return n
+      n.to_i64? || n
     end
 
     def next_column_index : Int32

--- a/spec/serializable_spec.cr
+++ b/spec/serializable_spec.cr
@@ -90,10 +90,10 @@ struct ModelWithEnum
   getter c2 : MyOtherEnum
 
   enum MyEnum
-    Foo
-    Bar
-    Baz
-    Quux
+    Foo  = 0
+    Bar  = 1
+    Baz  = 2
+    Quux = 3
   end
 
   enum MyOtherEnum
@@ -196,7 +196,7 @@ describe "DB::Serializable" do
   end
 
   it "should initialize a model with an enum property" do
-    expect_model("1,Baz,LOL", ModelWithEnum, {
+    expect_model("1,2,LOL", ModelWithEnum, {
       c0: 1,
       c1: ModelWithEnum::MyEnum::Baz,
       c2: ModelWithEnum::MyOtherEnum::LOL,

--- a/src/db/result_set.cr
+++ b/src/db/result_set.cr
@@ -164,7 +164,7 @@ struct Enum
       from_value value
     else
       raise DB::ColumnTypeMismatchError.new(
-        context: "#{self}#new(rs : DB::ResultSet)",
+        context: "#{self}.new(rs : DB::ResultSet)",
         column_index: index,
         column_name: rs.column_name(index),
         column_type: value.class.to_s,

--- a/src/db/result_set.cr
+++ b/src/db/result_set.cr
@@ -159,9 +159,9 @@ struct Enum
 
     case value = rs.read
     when String
-      result = parse value
+      parse value
     when Int
-      result = from_value value
+      from_value value
     else
       raise DB::ColumnTypeMismatchError.new(
         context: "#{self}#new(rs : DB::ResultSet)",
@@ -171,7 +171,5 @@ struct Enum
         expected_type: "String | Int",
       )
     end
-
-    result
   end
 end

--- a/src/db/result_set.cr
+++ b/src/db/result_set.cr
@@ -96,6 +96,23 @@ module DB
       end
     end
 
+    # Read the value based on the given `enum` type, supporting both string and
+    # numeric column types.
+    #
+    # ```
+    # enum Status
+    #   Pending
+    #   Complete
+    # end
+    #
+    # db.query "SELECT 'complete'" do |rs|
+    #   rs.read Status # => Status::Complete
+    # end
+    # ```
+    def read(type : Enum.class)
+      type.new(self)
+    end
+
     # Reads the next columns and returns a tuple of the values.
     def read(*types : Class)
       internal_read(*types)
@@ -133,5 +150,28 @@ module DB
     # def read_text
     #   yield ... io ....
     # end
+  end
+end
+
+struct Enum
+  def self.new(rs : DB::ResultSet) : self
+    index = rs.next_column_index
+
+    case value = rs.read
+    when String
+      result = parse value
+    when Int
+      result = from_value value
+    else
+      raise DB::ColumnTypeMismatchError.new(
+        context: "#{self}#new(rs : DB::ResultSet)",
+        column_index: index,
+        column_name: rs.column_name(index),
+        column_type: to_s,
+        expected_type: "String | Int",
+      )
+    end
+
+    result
   end
 end

--- a/src/db/result_set.cr
+++ b/src/db/result_set.cr
@@ -167,7 +167,7 @@ struct Enum
         context: "#{self}#new(rs : DB::ResultSet)",
         column_index: index,
         column_name: rs.column_name(index),
-        column_type: to_s,
+        column_type: value.class.to_s,
         expected_type: "String | Int",
       )
     end


### PR DESCRIPTION
I often want one or more properties of my DB-backed models to be constrained to a low-cardinality set of values, which can be known at compile time. Usually I end up storing them in strings, but then I can't lean on the Crystal type system to help me constrain those values throughout my application.

Since the `JSON` module supports Crystal enums, I looked into adding support for them here, as well. With this I can remove the translation layer between the HTTP layer and the DB layer if the only difference between them is an `enum`.

I was originally going to add a macro so you'd do something like `DB.register_type MyEnum`, but then I remembered that `Enum` is itself a Crystal type that represents all `enum`s to the exclusion of all else, which made it really simple to support without doing any extra work.