### PR TITLE
Add support for connection pool health checks

### DIFF
--- a/src/db/connection.cr
+++ b/src/db/connection.cr
@@ -31,7 +31,11 @@ module DB
     # :nodoc:
     property auto_release : Bool = true
 
+    @created_at : Time
+    getter created_at
+
     def initialize(@context : ConnectionContext)
+      @created_at = Time.utc
       @prepared_statements = @context.prepared_statements?
     end
 
@@ -50,6 +54,9 @@ module DB
       raise DB::Error.new("There is an existing transaction in this connection") if @transaction
       @transaction = true
       create_transaction
+    end
+
+    protected def check
     end
 
     protected def create_transaction : Transaction

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -59,6 +59,7 @@ module DB
         @setup_connection.call conn
         conn
       }
+      @pool.start_reaper!
     end
 
     # Run the specified block every time a new connection is established, yielding the new connection

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -36,6 +36,8 @@ module DB
         checkout_timeout:   params.fetch("checkout_timeout", 5.0).to_f,
         retry_attempts:     params.fetch("retry_attempts", 1).to_i,
         retry_delay:        params.fetch("retry_delay", 1.0).to_f,
+        reaping_frequency:  params.fetch("reaping_frequency", 60.0).to_f,
+        reaping_delay:      params.fetch("reaping_delay", 60.0).to_f,
       }
     end
   end


### PR DESCRIPTION
Resolves #169 

Provides an API to address disconnections to
long-running connections that occur outside code
by adding support for periodic health checks on idle
connections.

Periodic connection reapers cycle through a list of
idle connections, and call a #check method provided by the
connection. Check methods should either result in success on in
raising a PoolResourceLost(T) error such as DB::ConnectionLost.

Connections that fail a health check are replaced within the Connection Pool.

---

PR Notes:

Most pools in various languages handle this with rescuing the failed connection, ejecting it from the pool, and retrying -- this adds latency spikes and in my apps was actually triggering DB::ConnectionLost errors (probably due to retry_attempts + retry_delay not being able to get a successful retry in before timing out, but I'm not entirely certain).

Golang and Java both have ConnectionPools that introduce a TTL for connections and kill them. I initially experimented with that, but killing all idle connections, regardless of their current health, was fairly inefficient and created a large number of unnecessary allocations.

Instead of going with a TTL-based approach, I implemented an optional "health check" that adapters can add to their Connection class. https://github.com/the-business-factory/crystal-pg/pull/1 pairs with this PR 🍷 🧀 and implements a very simple health check.

In a demo low traffic app @ https://hirobot.app/ the health check itself has eliminated the disconnects, where earlier attempts at implementing TCP keepalive settings on PG, the server, and the database did not; it appears that some firewall or cluster-level disconnects are prevented by the periodic ACK.