### PR TITLE
Add DuckDB driver to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Common db api for crystal. You will need to have a specific driver to access a d
 * [PostgreSQL](https://github.com/will/crystal-pg)
 * [ODBC](https://github.com/naqvis/crystal-odbc)
 * [Cassandra](https://github.com/kaukas/crystal-cassandra)
+* [DuckDB](https://github.com/amauryt/crystal-duckdb)
 
 ## Installation
 


### PR DESCRIPTION
After more than a year of using and maintaining the driver I think it is stable enough to be listed on crystal-db.