### PR TITLE
Fix positional parameter warnings

### DIFF
--- a/spec/custom_drivers_types_spec.cr
+++ b/spec/custom_drivers_types_spec.cr
@@ -52,11 +52,11 @@ class FooDriver < DB::Driver
   end
 
   class FooConnection < DB::Connection
-    def build_prepared_statement(command) : DB::Statement
-      FooStatement.new(self, command)
+    def build_prepared_statement(query) : DB::Statement
+      FooStatement.new(self, query)
     end
 
-    def build_unprepared_statement(command) : DB::Statement
+    def build_unprepared_statement(query) : DB::Statement
       raise "not implemented"
     end
   end


### PR DESCRIPTION
Fixes these warnings for positional parameter mismatches. This warning was introduced in Crystal 1.5.0 (https://github.com/crystal-lang/crystal/pull/11915 https://github.com/crystal-lang/crystal/pull/12167).
```
In spec/custom_drivers_types_spec.cr:55:34

 55 | def build_prepared_statement(command) : DB::Statement
                                   ^------
Warning: positional parameter 'command' corresponds to parameter 'query' of the overridden method DB::Connection#build_prepared_statement(
query), which has a different name and may affect named argument passing

In spec/custom_drivers_types_spec.cr:59:36

 59 | def build_unprepared_statement(command) : DB::Statement
                                     ^------
Warning: positional parameter 'command' corresponds to parameter 'query' of the overridden method DB::Connection#build_unprepared_statemen
t(query), which has a different name and may affect named argument passing
```