### PR TITLE
Add io_provider to DB.open / DB.connect

### DIFF
--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -9,6 +9,7 @@ class DummyDriver < DB::Driver
   class DummyConnection < DB::Connection
     def initialize(context)
       super(context)
+      context.io_provider.try &.build_io
       @connected = true
       @@connections ||= [] of DummyConnection
       @@connections.not_nil! << self

--- a/spec/io_provider_spec.cr
+++ b/spec/io_provider_spec.cr
@@ -1,0 +1,54 @@
+require "./spec_helper"
+require "log/spec"
+
+class DummyIOProvider < DB::IOProvider
+  @setup_called = false
+  @teardown_called = false
+
+  def setup : Void
+    raise "setup called twice" if @setup_called
+    @setup_called = true
+    DB::Log.debug &.emit("DummyIOProvider#setup")
+  end
+
+  def teardown : Void
+    raise "teardown called twice" if @teardown_called
+    @teardown_called = true
+    DB::Log.debug &.emit("DummyIOProvider#teardown")
+  end
+
+  def build_io : IO
+    DB::Log.debug &.emit("DummyIOProvider#build_io")
+    return IO::Memory.new
+  end
+end
+
+describe DB::IOProvider do
+  it "setup/teardown are called for pool connection" do
+    Log.capture(DB::Log.source) do |logs|
+      DB.open "dummy://host", io_provider: DummyIOProvider.new do |db|
+        cnn1 = db.checkout
+        cnn2 = db.checkout
+
+        db.release(cnn1)
+        db.release(cnn2)
+      end
+
+      logs.check(:debug, /DummyIOProvider#setup/i)
+      logs.check(:debug, /DummyIOProvider#build_io/i)
+      logs.check(:debug, /DummyIOProvider#build_io/i)
+      logs.check(:debug, /DummyIOProvider#teardown/i)
+    end
+  end
+
+  it "setup/teardown are called for single connection" do
+    Log.capture(DB::Log.source) do |logs|
+      DB.connect "dummy://host", io_provider: DummyIOProvider.new do |cnn|
+      end
+
+      logs.check(:debug, /DummyIOProvider#setup/i)
+      logs.check(:debug, /DummyIOProvider#build_io/i)
+      logs.check(:debug, /DummyIOProvider#teardown/i)
+    end
+  end
+end

--- a/src/db.cr
+++ b/src/db.cr
@@ -115,13 +115,13 @@ module DB
   # to each database driver's specific format.
   #
   # The returned database must be closed by `Database#close`.
-  def self.open(uri : URI | String)
-    build_database(uri)
+  def self.open(uri : URI | String, *, io_provider : IOProvider? = nil)
+    build_database(uri, io_provider: io_provider)
   end
 
   # Same as `#open` but the database is yielded and closed automatically at the end of the block.
-  def self.open(uri : URI | String, &block)
-    db = build_database(uri)
+  def self.open(uri : URI | String, *, io_provider : IOProvider? = nil, &block)
+    db = build_database(uri, io_provider: io_provider)
     begin
       yield db
     ensure
@@ -133,13 +133,13 @@ module DB
   # The scheme of the *uri* determines the driver to use.
   # Returned connection must be closed by `Connection#close`.
   # If a block is used the connection is yielded and closed automatically.
-  def self.connect(uri : URI | String)
-    build_connection(uri)
+  def self.connect(uri : URI | String, *, io_provider : IOProvider? = nil)
+    build_connection(uri, io_provider: io_provider)
   end
 
   # :ditto:
-  def self.connect(uri : URI | String, &block)
-    cnn = build_connection(uri)
+  def self.connect(uri : URI | String, *, io_provider : IOProvider? = nil, &block)
+    cnn = build_connection(uri, io_provider: io_provider)
     begin
       yield cnn
     ensure
@@ -147,20 +147,20 @@ module DB
     end
   end
 
-  private def self.build_database(connection_string : String)
-    build_database(URI.parse(connection_string))
+  private def self.build_database(connection_string : String, *, io_provider : IOProvider?)
+    build_database(URI.parse(connection_string), io_provider: io_provider)
   end
 
-  private def self.build_database(uri : URI)
-    Database.new(build_driver(uri), uri)
+  private def self.build_database(uri : URI, *, io_provider : IOProvider?)
+    Database.new(build_driver(uri), uri, io_provider)
   end
 
-  private def self.build_connection(connection_string : String)
-    build_connection(URI.parse(connection_string))
+  private def self.build_connection(connection_string : String, *, io_provider : IOProvider?)
+    build_connection(URI.parse(connection_string), io_provider: io_provider)
   end
 
-  private def self.build_connection(uri : URI)
-    build_driver(uri).build_connection(SingleConnectionContext.new(uri)).as(Connection)
+  private def self.build_connection(uri : URI, *, io_provider : IOProvider?)
+    build_driver(uri).build_connection(SingleConnectionContext.new(uri, io_provider)).as(Connection)
   end
 
   private def self.build_driver(uri : URI)
@@ -182,6 +182,7 @@ module DB
   end
 end
 
+require "./db/io_provider"
 require "./db/pool"
 require "./db/string_key_cache"
 require "./db/enumerable_concat"

--- a/src/db/connection_context.cr
+++ b/src/db/connection_context.cr
@@ -3,6 +3,9 @@ module DB
     # Returns the uri with the connection settings to the database
     abstract def uri : URI
 
+    # Returns the io_provider to use
+    abstract def io_provider : IOProvider?
+
     # Return whether the statements should be prepared by default
     abstract def prepared_statements? : Bool
 
@@ -20,9 +23,10 @@ module DB
     include ConnectionContext
 
     getter uri : URI
+    getter io_provider : IOProvider?
     getter? prepared_statements : Bool
 
-    def initialize(@uri : URI)
+    def initialize(@uri : URI, @io_provider : IOProvider?)
       params = HTTP::Params.parse(uri.query || "")
       @prepared_statements = DB.fetch_bool(params, "prepared_statements", true)
     end

--- a/src/db/connection_context.cr
+++ b/src/db/connection_context.cr
@@ -29,9 +29,11 @@ module DB
     def initialize(@uri : URI, @io_provider : IOProvider?)
       params = HTTP::Params.parse(uri.query || "")
       @prepared_statements = DB.fetch_bool(params, "prepared_statements", true)
+      @io_provider.try &.setup
     end
 
     def discard(connection : Connection)
+      @io_provider.try &.teardown
     end
 
     def release(connection : Connection)

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -39,6 +39,9 @@ module DB
     # Returns the uri with the connection settings to the database
     getter uri : URI
 
+    # :nodoc:
+    getter io_provider : IOProvider?
+
     getter? prepared_statements : Bool
 
     @pool : Pool(Connection)
@@ -46,7 +49,7 @@ module DB
     @statements_cache = StringKeyCache(PoolPreparedStatement).new
 
     # :nodoc:
-    def initialize(@driver : Driver, @uri : URI)
+    def initialize(@driver : Driver, @uri : URI, @io_provider : IOProvider?)
       params = HTTP::Params.parse(uri.query || "")
       @prepared_statements = DB.fetch_bool(params, "prepared_statements", true)
       pool_options = @driver.connection_pool_options(params)

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -54,6 +54,8 @@ module DB
       @prepared_statements = DB.fetch_bool(params, "prepared_statements", true)
       pool_options = @driver.connection_pool_options(params)
 
+      @io_provider.try &.setup
+
       @setup_connection = ->(conn : Connection) {}
       @pool = uninitialized Pool(Connection) # in order to use self in the factory proc
       @pool = Pool.new(**pool_options) {
@@ -86,6 +88,8 @@ module DB
       @statements_cache.clear
 
       @pool.close
+
+      @io_provider.try &.teardown
     end
 
     # :nodoc:

--- a/src/db/io_provider.cr
+++ b/src/db/io_provider.cr
@@ -2,6 +2,10 @@ module DB
   # An `IOProvider` can be used to customize
   # how underlying IO for connections are created.
   # Not all drivers are backed by IO.
+  #
+  # The setup and teardown methods will be called once
+  # per Database Connection Pool when DB.open is used,
+  # and once for the single connection when DB.connect is used.
   abstract class IOProvider
     abstract def setup : Void
 

--- a/src/db/io_provider.cr
+++ b/src/db/io_provider.cr
@@ -1,0 +1,12 @@
+module DB
+  # An `IOProvider` can be used to customize
+  # how underlying IO for connections are created.
+  # Not all drivers are backed by IO.
+  abstract class IOProvider
+    abstract def setup : Void
+
+    abstract def teardown : Void
+
+    abstract def build_io : IO
+  end
+end


### PR DESCRIPTION
Fixes #162 .

Drivers implementation should call `ConnectionContext#io_provider : DB::IOProvider?` method to optionally use the the specified provider.

Since not all drivers are IO based is hard to make this parameter mandatory.

I would like to discuss what should be a nice default. Maybe providing TCPSocket or UnixSocket builders directly based on the hostname as crystal-pg does. But for dice each driver would need some default_port at least since that is driver specific. Maybe the default io_provider should also be driver specific and DB provide a base implementation.