### PR TITLE
Use https link for API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Note: Multiple drivers can be included in the same application.
 
 ## Documentation
 
-* [Latest API](http://crystal-lang.github.io/crystal-db/api/latest/)
+* [Latest API](https://crystal-lang.github.io/crystal-db/api/latest/)
 * [Crystal book](https://crystal-lang.org/docs/database/)
 
 ## Usage


### PR DESCRIPTION
Linking to [the https site](https://crystal-lang.github.io/crystal-db/api/latest/) mostly to avoid the "Not Secure" warning in my browser, but also because it's a good idea