### PR TITLE
Refactor connection factory

### DIFF
--- a/spec/custom_drivers_types_spec.cr
+++ b/spec/custom_drivers_types_spec.cr
@@ -36,6 +36,15 @@ class FooValue
 end
 
 class FooDriver < DB::Driver
+  class FooConnectionBuilder < DB::ConnectionBuilder
+    def initialize(@options : DB::Connection::Options)
+    end
+
+    def build : DB::Connection
+      FooConnection.new(@options)
+    end
+  end
+
   alias Any = DB::Any | FooValue
   @@row = [] of Any
 
@@ -47,10 +56,9 @@ class FooDriver < DB::Driver
     @@row
   end
 
-  def connection_builder(uri : URI) : Proc(DB::Connection)
+  def connection_builder(uri : URI) : DB::ConnectionBuilder
     params = HTTP::Params.parse(uri.query || "")
-    options = connection_options(params)
-    ->{ FooConnection.new(options).as(DB::Connection) }
+    FooConnectionBuilder.new(connection_options(params))
   end
 
   class FooConnection < DB::Connection
@@ -101,6 +109,15 @@ class BarValue
 end
 
 class BarDriver < DB::Driver
+  class BarConnectionBuilder < DB::ConnectionBuilder
+    def initialize(@options : DB::Connection::Options)
+    end
+
+    def build : DB::Connection
+      BarConnection.new(@options)
+    end
+  end
+
   alias Any = DB::Any | BarValue
   @@row = [] of Any
 
@@ -112,10 +129,9 @@ class BarDriver < DB::Driver
     @@row
   end
 
-  def connection_builder(uri : URI) : Proc(DB::Connection)
+  def connection_builder(uri : URI) : DB::ConnectionBuilder
     params = HTTP::Params.parse(uri.query || "")
-    options = connection_options(params)
-    ->{ BarConnection.new(options).as(DB::Connection) }
+    BarConnectionBuilder.new(connection_options(params))
   end
 
   class BarConnection < DB::Connection

--- a/spec/custom_drivers_types_spec.cr
+++ b/spec/custom_drivers_types_spec.cr
@@ -47,8 +47,8 @@ class FooDriver < DB::Driver
     @@row
   end
 
-  def build_connection(context : DB::ConnectionContext) : DB::Connection
-    FooConnection.new
+  def connection_builder(uri : URI) : Proc(DB::Connection)
+    -> { FooConnection.new.as(DB::Connection) }
   end
 
   class FooConnection < DB::Connection
@@ -110,8 +110,8 @@ class BarDriver < DB::Driver
     @@row
   end
 
-  def build_connection(context : DB::ConnectionContext) : DB::Connection
-    BarConnection.new
+  def connection_builder(uri : URI) : Proc(DB::Connection)
+    -> { BarConnection.new.as(DB::Connection) }
   end
 
   class BarConnection < DB::Connection

--- a/spec/custom_drivers_types_spec.cr
+++ b/spec/custom_drivers_types_spec.cr
@@ -160,8 +160,8 @@ DB.register_driver "bar", BarDriver
 
 describe DB do
   it "should be able to register multiple drivers" do
-    DB.open("foo://host").driver.should be_a(FooDriver)
-    DB.open("bar://host").driver.should be_a(BarDriver)
+    DB.open("foo://host").checkout.should be_a(FooDriver::FooConnection)
+    DB.open("bar://host").checkout.should be_a(BarDriver::BarConnection)
   end
 
   it "Foo and Bar drivers should return fake_row" do

--- a/spec/custom_drivers_types_spec.cr
+++ b/spec/custom_drivers_types_spec.cr
@@ -49,7 +49,7 @@ class FooDriver < DB::Driver
 
   def connection_builder(uri : URI) : Proc(DB::Connection)
     params = HTTP::Params.parse(uri.query || "")
-    options = DB::Connection::Options.from_http_params(params)
+    options = connection_options(params)
     ->{ FooConnection.new(options).as(DB::Connection) }
   end
 
@@ -114,7 +114,7 @@ class BarDriver < DB::Driver
 
   def connection_builder(uri : URI) : Proc(DB::Connection)
     params = HTTP::Params.parse(uri.query || "")
-    options = DB::Connection::Options.from_http_params(params)
+    options = connection_options(params)
     ->{ BarConnection.new(options).as(DB::Connection) }
   end
 

--- a/spec/custom_drivers_types_spec.cr
+++ b/spec/custom_drivers_types_spec.cr
@@ -48,7 +48,9 @@ class FooDriver < DB::Driver
   end
 
   def connection_builder(uri : URI) : Proc(DB::Connection)
-    -> { FooConnection.new.as(DB::Connection) }
+    params = HTTP::Params.parse(uri.query || "")
+    options = DB::Connection::Options.from_http_params(params)
+    ->{ FooConnection.new(options).as(DB::Connection) }
   end
 
   class FooConnection < DB::Connection
@@ -111,7 +113,9 @@ class BarDriver < DB::Driver
   end
 
   def connection_builder(uri : URI) : Proc(DB::Connection)
-    -> { BarConnection.new.as(DB::Connection) }
+    params = HTTP::Params.parse(uri.query || "")
+    options = DB::Connection::Options.from_http_params(params)
+    ->{ BarConnection.new(options).as(DB::Connection) }
   end
 
   class BarConnection < DB::Connection

--- a/spec/custom_drivers_types_spec.cr
+++ b/spec/custom_drivers_types_spec.cr
@@ -48,7 +48,7 @@ class FooDriver < DB::Driver
   end
 
   def build_connection(context : DB::ConnectionContext) : DB::Connection
-    FooConnection.new(context)
+    FooConnection.new
   end
 
   class FooConnection < DB::Connection
@@ -111,7 +111,7 @@ class BarDriver < DB::Driver
   end
 
   def build_connection(context : DB::ConnectionContext) : DB::Connection
-    BarConnection.new(context)
+    BarConnection.new
   end
 
   class BarConnection < DB::Connection

--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -9,12 +9,9 @@ describe DB do
     DB.driver_class("dummy").should eq(DummyDriver)
   end
 
-  it "should instantiate driver with connection uri" do
+  it "should create dummy connection" do
     db = DB.open "dummy://localhost:1027"
-    db.driver.should be_a(DummyDriver)
-    db.uri.scheme.should eq("dummy")
-    db.uri.host.should eq("localhost")
-    db.uri.port.should eq(1027)
+    db.checkout.should be_a(DummyDriver::DummyConnection)
   end
 
   it "should create a connection and close it" do

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -2,8 +2,8 @@ require "spec"
 require "../src/db"
 
 class DummyDriver < DB::Driver
-  def build_connection(context : DB::ConnectionContext) : DB::Connection
-    DummyConnection.new
+  def connection_builder(uri : URI) : Proc(DB::Connection)
+    -> { DummyConnection.new.as(DB::Connection) }
   end
 
   class DummyConnection < DB::Connection

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -2,10 +2,18 @@ require "spec"
 require "../src/db"
 
 class DummyDriver < DB::Driver
-  def connection_builder(uri : URI) : Proc(DB::Connection)
+  class DummyConnectionBuilder < DB::ConnectionBuilder
+    def initialize(@options : DB::Connection::Options)
+    end
+
+    def build : DB::Connection
+      DummyConnection.new(@options)
+    end
+  end
+
+  def connection_builder(uri : URI) : DB::ConnectionBuilder
     params = HTTP::Params.parse(uri.query || "")
-    options = connection_options(params)
-    ->{ DummyConnection.new(options).as(DB::Connection) }
+    DummyConnectionBuilder.new(connection_options(params))
   end
 
   class DummyConnection < DB::Connection

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -4,7 +4,7 @@ require "../src/db"
 class DummyDriver < DB::Driver
   def connection_builder(uri : URI) : Proc(DB::Connection)
     params = HTTP::Params.parse(uri.query || "")
-    options = DB::Connection::Options.from_http_params(params)
+    options = connection_options(params)
     ->{ DummyConnection.new(options).as(DB::Connection) }
   end
 

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -3,11 +3,14 @@ require "../src/db"
 
 class DummyDriver < DB::Driver
   def connection_builder(uri : URI) : Proc(DB::Connection)
-    -> { DummyConnection.new.as(DB::Connection) }
+    params = HTTP::Params.parse(uri.query || "")
+    options = DB::Connection::Options.from_http_params(params)
+    ->{ DummyConnection.new(options).as(DB::Connection) }
   end
 
   class DummyConnection < DB::Connection
-    def initialize
+    def initialize(options : DB::Connection::Options)
+      super(options)
       @connected = true
       @@connections ||= [] of DummyConnection
       @@connections.not_nil! << self

--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -3,12 +3,11 @@ require "../src/db"
 
 class DummyDriver < DB::Driver
   def build_connection(context : DB::ConnectionContext) : DB::Connection
-    DummyConnection.new(context)
+    DummyConnection.new
   end
 
   class DummyConnection < DB::Connection
-    def initialize(context)
-      super(context)
+    def initialize
       @connected = true
       @@connections ||= [] of DummyConnection
       @@connections.not_nil! << self

--- a/spec/http_client_pool_spec.cr
+++ b/spec/http_client_pool_spec.cr
@@ -22,10 +22,10 @@ describe DB::Pool do
       expected_per_connection = 5
       requests = fixed_pool_size * expected_per_connection
 
-      pool = DB::Pool.new(
+      pool = DB::Pool.new(DB::Pool::Options.new(
         initial_pool_size: fixed_pool_size,
         max_pool_size: fixed_pool_size,
-        max_idle_pool_size: fixed_pool_size) {
+        max_idle_pool_size: fixed_pool_size)) {
         HTTP::Client.new(URI.parse("http://127.0.0.1:#{address.port}/"))
       }
 

--- a/src/db.cr
+++ b/src/db.cr
@@ -161,7 +161,7 @@ module DB
 
   private def self.build_connection(uri : URI)
     # PENDING: parse connection options from uri and set the right connection context
-    build_driver(uri).build_connection(SingleConnectionContext.default).as(Connection)
+    build_driver(uri).connection_builder(uri).call
   end
 
   private def self.build_driver(uri : URI)

--- a/src/db.cr
+++ b/src/db.cr
@@ -152,7 +152,12 @@ module DB
   end
 
   private def self.build_database(uri : URI)
-    Database.new(build_driver(uri), uri)
+    driver = build_driver(uri)
+    params = HTTP::Params.parse(uri.query || "")
+    connection_options = driver.connection_options(params)
+    pool_options = driver.pool_options(params)
+    factory = driver.connection_builder(uri)
+    Database.new(connection_options, pool_options, &factory)
   end
 
   private def self.build_connection(connection_string : String)

--- a/src/db.cr
+++ b/src/db.cr
@@ -156,7 +156,8 @@ module DB
     params = HTTP::Params.parse(uri.query || "")
     connection_options = driver.connection_options(params)
     pool_options = driver.pool_options(params)
-    factory = driver.connection_builder(uri)
+    builder = driver.connection_builder(uri)
+    factory = ->{ builder.build }
     Database.new(connection_options, pool_options, &factory)
   end
 
@@ -165,7 +166,7 @@ module DB
   end
 
   private def self.build_connection(uri : URI)
-    build_driver(uri).connection_builder(uri).call
+    build_driver(uri).connection_builder(uri).build
   end
 
   private def self.build_driver(uri : URI)
@@ -193,6 +194,7 @@ require "./db/enumerable_concat"
 require "./db/query_methods"
 require "./db/session_methods"
 require "./db/disposable"
+require "./db/connection_builder"
 require "./db/driver"
 require "./db/statement"
 require "./db/begin_transaction"

--- a/src/db.cr
+++ b/src/db.cr
@@ -160,7 +160,8 @@ module DB
   end
 
   private def self.build_connection(uri : URI)
-    build_driver(uri).build_connection(SingleConnectionContext.new(uri)).as(Connection)
+    # PENDING: parse connection options from uri and set the right connection context
+    build_driver(uri).build_connection(SingleConnectionContext.default).as(Connection)
   end
 
   private def self.build_driver(uri : URI)

--- a/src/db.cr
+++ b/src/db.cr
@@ -160,7 +160,6 @@ module DB
   end
 
   private def self.build_connection(uri : URI)
-    # PENDING: parse connection options from uri and set the right connection context
     build_driver(uri).connection_builder(uri).call
   end
 

--- a/src/db/connection.cr
+++ b/src/db/connection.cr
@@ -24,15 +24,14 @@ module DB
     include BeginTransaction
 
     # :nodoc:
-    getter context
+    property context : ConnectionContext = SingleConnectionContext.default
     @statements_cache = StringKeyCache(Statement).new
     @transaction = false
-    getter? prepared_statements : Bool
     # :nodoc:
     property auto_release : Bool = true
 
-    def initialize(@context : ConnectionContext)
-      @prepared_statements = @context.prepared_statements?
+    def prepared_statements? : Bool
+      context.prepared_statements?
     end
 
     # :nodoc:
@@ -59,7 +58,7 @@ module DB
     protected def do_close
       @statements_cache.each_value &.close
       @statements_cache.clear
-      @context.discard self
+      context.discard self
     end
 
     # :nodoc:
@@ -75,7 +74,7 @@ module DB
     # managed by the database. Should be used
     # only if the connection was obtained by `Database#checkout`.
     def release
-      @context.release(self)
+      context.release(self)
     end
 
     # :nodoc:

--- a/src/db/connection.cr
+++ b/src/db/connection.cr
@@ -23,6 +23,16 @@ module DB
     include SessionMethods(Connection, Statement)
     include BeginTransaction
 
+    record Options,
+      # Return whether the statements should be prepared by default
+      prepared_statements : Bool = true do
+      def self.from_http_params(params : HTTP::Params, default = Options.new)
+        Options.new(
+          prepared_statements: DB.fetch_bool(params, "prepared_statements", default.prepared_statements)
+        )
+      end
+    end
+
     # :nodoc:
     property context : ConnectionContext = SingleConnectionContext.default
     @statements_cache = StringKeyCache(Statement).new
@@ -30,8 +40,11 @@ module DB
     # :nodoc:
     property auto_release : Bool = true
 
+    def initialize(@options : Options)
+    end
+
     def prepared_statements? : Bool
-      context.prepared_statements?
+      @options.prepared_statements
     end
 
     # :nodoc:

--- a/src/db/connection_builder.cr
+++ b/src/db/connection_builder.cr
@@ -1,0 +1,8 @@
+module DB
+  # A connection factory with a specific configuration.
+  #
+  # See `Driver#connection_builder`.
+  abstract class ConnectionBuilder
+    abstract def build : Connection
+  end
+end

--- a/src/db/connection_context.cr
+++ b/src/db/connection_context.cr
@@ -1,8 +1,5 @@
 module DB
   module ConnectionContext
-    # Return whether the statements should be prepared by default
-    abstract def prepared_statements? : Bool
-
     # Indicates that the *connection* was permanently closed
     # and should not be used in the future.
     abstract def discard(connection : Connection)
@@ -16,12 +13,7 @@ module DB
   class SingleConnectionContext
     include ConnectionContext
 
-    class_getter default : SingleConnectionContext = SingleConnectionContext.new(true)
-
-    getter? prepared_statements : Bool
-
-    def initialize(@prepared_statements : Bool)
-    end
+    class_getter default : SingleConnectionContext = SingleConnectionContext.new
 
     def discard(connection : Connection)
     end

--- a/src/db/connection_context.cr
+++ b/src/db/connection_context.cr
@@ -1,8 +1,5 @@
 module DB
   module ConnectionContext
-    # Returns the uri with the connection settings to the database
-    abstract def uri : URI
-
     # Return whether the statements should be prepared by default
     abstract def prepared_statements? : Bool
 
@@ -19,12 +16,11 @@ module DB
   class SingleConnectionContext
     include ConnectionContext
 
-    getter uri : URI
+    class_getter default : SingleConnectionContext = SingleConnectionContext.new(true)
+
     getter? prepared_statements : Bool
 
-    def initialize(@uri : URI)
-      params = HTTP::Params.parse(uri.query || "")
-      @prepared_statements = DB.fetch_bool(params, "prepared_statements", true)
+    def initialize(@prepared_statements : Bool)
     end
 
     def discard(connection : Connection)

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -53,7 +53,7 @@ module DB
       @setup_connection = ->(conn : Connection) {}
       factory = @driver.connection_builder(@uri)
       @pool = uninitialized Pool(Connection) # in order to use self in the factory proc
-      @pool = Pool.new(**pool_options) {
+      @pool = Pool.new(pool_options) {
         conn = factory.call
         conn.auto_release = false
         conn.context = self

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -32,8 +32,6 @@ module DB
     include ConnectionContext
 
     # :nodoc:
-    getter driver
-    # :nodoc:
     getter pool
 
     # Returns the uri with the connection settings to the database
@@ -45,13 +43,13 @@ module DB
     @statements_cache = StringKeyCache(PoolPreparedStatement).new
 
     # :nodoc:
-    def initialize(@driver : Driver, @uri : URI)
+    def initialize(driver : Driver, @uri : URI)
       params = HTTP::Params.parse(uri.query || "")
-      @connection_options = @driver.connection_options(params)
-      pool_options = @driver.pool_options(params)
+      @connection_options = driver.connection_options(params)
+      pool_options = driver.pool_options(params)
 
       @setup_connection = ->(conn : Connection) {}
-      factory = @driver.connection_builder(@uri)
+      factory = driver.connection_builder(@uri)
       @pool = uninitialized Pool(Connection) # in order to use self in the factory proc
       @pool = Pool.new(pool_options) {
         conn = factory.call

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -46,7 +46,7 @@ module DB
       @connection_options = connection_options
       @setup_connection = ->(conn : Connection) {}
       @pool = uninitialized Pool(Connection) # in order to use self in the factory proc
-      @pool = Pool.new(pool_options) {
+      @pool = Pool(Connection).new(pool_options) {
         conn = factory.call
         conn.auto_release = false
         conn.context = self

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -39,8 +39,7 @@ module DB
     # Returns the uri with the connection settings to the database
     getter uri : URI
 
-    getter? prepared_statements : Bool
-
+    @connection_options : Connection::Options
     @pool : Pool(Connection)
     @setup_connection : Connection -> Nil
     @statements_cache = StringKeyCache(PoolPreparedStatement).new
@@ -48,7 +47,7 @@ module DB
     # :nodoc:
     def initialize(@driver : Driver, @uri : URI)
       params = HTTP::Params.parse(uri.query || "")
-      @prepared_statements = DB.fetch_bool(params, "prepared_statements", true)
+      @connection_options = @driver.connection_options(params)
       pool_options = @driver.connection_pool_options(params)
 
       @setup_connection = ->(conn : Connection) {}
@@ -61,6 +60,10 @@ module DB
         @setup_connection.call conn
         conn
       }
+    end
+
+    def prepared_statements? : Bool
+      @connection_options.prepared_statements
     end
 
     # Run the specified block every time a new connection is established, yielding the new connection

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -10,8 +10,9 @@ module DB
   #
   # ## Database URI
   #
-  # Connection parameters are configured in a URI. The format is specified by the individual
-  # database drivers. See the [reference book](https://crystal-lang.org/reference/database/) for examples.
+  # Connection parameters are usually in a URI. The format is specified by the individual
+  # database drivers, yet there are some common properties names usually shared.
+  # See the [reference book](https://crystal-lang.org/reference/database/) for examples.
   #
   # The connection pool can be configured from URI parameters:
   #

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -56,6 +56,7 @@ module DB
       @pool = Pool.new(**pool_options) {
         conn = @driver.build_connection(self).as(Connection)
         conn.auto_release = false
+        conn.context = self
         @setup_connection.call conn
         conn
       }

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -48,7 +48,7 @@ module DB
     def initialize(@driver : Driver, @uri : URI)
       params = HTTP::Params.parse(uri.query || "")
       @connection_options = @driver.connection_options(params)
-      pool_options = @driver.connection_pool_options(params)
+      pool_options = @driver.pool_options(params)
 
       @setup_connection = ->(conn : Connection) {}
       factory = @driver.connection_builder(@uri)

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -39,15 +39,6 @@ module DB
     @setup_connection : Connection -> Nil
     @statements_cache = StringKeyCache(PoolPreparedStatement).new
 
-    # :nodoc:
-    def initialize(driver : Driver, uri : URI)
-      params = HTTP::Params.parse(uri.query || "")
-      connection_options = driver.connection_options(params)
-      pool_options = driver.pool_options(params)
-      factory = driver.connection_builder(uri)
-      initialize(connection_options, pool_options, &factory)
-    end
-
     # Initialize a database with the specified options and connection factory.
     # This covers more advanced use cases that might not be supported by an URI connection string such as tunneling connection.
     def initialize(connection_options : Connection::Options, pool_options : Pool::Options, &factory : -> Connection)

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -34,22 +34,19 @@ module DB
     # :nodoc:
     getter pool
 
-    # Returns the uri with the connection settings to the database
-    getter uri : URI
-
     @connection_options : Connection::Options
     @pool : Pool(Connection)
     @setup_connection : Connection -> Nil
     @statements_cache = StringKeyCache(PoolPreparedStatement).new
 
     # :nodoc:
-    def initialize(driver : Driver, @uri : URI)
+    def initialize(driver : Driver, uri : URI)
       params = HTTP::Params.parse(uri.query || "")
       @connection_options = driver.connection_options(params)
       pool_options = driver.pool_options(params)
 
       @setup_connection = ->(conn : Connection) {}
-      factory = driver.connection_builder(@uri)
+      factory = driver.connection_builder(uri)
       @pool = uninitialized Pool(Connection) # in order to use self in the factory proc
       @pool = Pool.new(pool_options) {
         conn = factory.call

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -52,9 +52,10 @@ module DB
       pool_options = @driver.connection_pool_options(params)
 
       @setup_connection = ->(conn : Connection) {}
+      factory = @driver.connection_builder(@uri)
       @pool = uninitialized Pool(Connection) # in order to use self in the factory proc
       @pool = Pool.new(**pool_options) {
-        conn = @driver.build_connection(self).as(Connection)
+        conn = factory.call
         conn.auto_release = false
         conn.context = self
         @setup_connection.call conn

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -34,7 +34,7 @@ module DB
     # Returns a new connection factory.
     #
     # NOTE: For implementors *uri* should be parsed once. If all the options
-    # are sound a factory Proc is returned.
+    # are sound a ConnectionBuilder is returned.
     abstract def connection_builder(uri : URI) : ConnectionBuilder
 
     def connection_options(params : HTTP::Params) : Connection::Options

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -36,7 +36,7 @@ module DB
       Connection::Options.from_http_params(params)
     end
 
-    def connection_pool_options(params : HTTP::Params) : Pool::Options
+    def pool_options(params : HTTP::Params) : Pool::Options
       Pool::Options.from_http_params(params)
     end
   end

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -26,7 +26,11 @@ module DB
   # Refer to `Connection`, `Statement` and `ResultSet` for further
   # driver implementation instructions.
   abstract class Driver
-    abstract def build_connection(context : ConnectionContext) : Connection
+    # Returns a new connection factory.
+    #
+    # NOTE: For implementors *uri* should be parsed once. If all the options
+    # are sound a factory Proc is returned.
+    abstract def connection_builder(uri : URI) : Proc(Connection)
 
     def connection_pool_options(params : HTTP::Params)
       {

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -1,21 +1,23 @@
 module DB
   # Database driver implementors must subclass `Driver`,
   # register with a driver_name using `DB#register_driver` and
-  # override the factory method `#build_connection`.
+  # override the factory method `#connection_builder`.
   #
   # ```
   # require "db"
   #
   # class FakeDriver < DB::Driver
-  #   def build_connection(context : DB::ConnectionContext)
-  #     FakeConnection.new context
+  #   def connection_builder(uri : URI) : Proc(DB::Connection)
+  #     params = HTTP::Params.parse(uri.query || "")
+  #     options = connection_options(params)
+  #     ->{ FakeConnection.new(options).as(DB::Connection) }
   #   end
   # end
   #
   # DB.register_driver "fake", FakeDriver
   # ```
   #
-  # Access to this fake datbase will be available with
+  # Access to this fake database will be available with
   #
   # ```
   # DB.open "fake://..." do |db|
@@ -25,6 +27,9 @@ module DB
   #
   # Refer to `Connection`, `Statement` and `ResultSet` for further
   # driver implementation instructions.
+  #
+  # Override `#connection_options` and `#pool_options` to provide custom
+  # defaults or parsing of the connection string URI.
   abstract class Driver
     # Returns a new connection factory.
     #

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -32,6 +32,10 @@ module DB
     # are sound a factory Proc is returned.
     abstract def connection_builder(uri : URI) : Proc(Connection)
 
+    def connection_options(params : HTTP::Params) : Connection::Options
+      Connection::Options.from_http_params(params)
+    end
+
     def connection_pool_options(params : HTTP::Params)
       {
         initial_pool_size:  params.fetch("initial_pool_size", 1).to_i,

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -36,15 +36,8 @@ module DB
       Connection::Options.from_http_params(params)
     end
 
-    def connection_pool_options(params : HTTP::Params)
-      {
-        initial_pool_size:  params.fetch("initial_pool_size", 1).to_i,
-        max_pool_size:      params.fetch("max_pool_size", 0).to_i,
-        max_idle_pool_size: params.fetch("max_idle_pool_size", 1).to_i,
-        checkout_timeout:   params.fetch("checkout_timeout", 5.0).to_f,
-        retry_attempts:     params.fetch("retry_attempts", 1).to_i,
-        retry_delay:        params.fetch("retry_delay", 1.0).to_f,
-      }
+    def connection_pool_options(params : HTTP::Params) : Pool::Options
+      Pool::Options.from_http_params(params)
     end
   end
 end

--- a/src/db/driver.cr
+++ b/src/db/driver.cr
@@ -35,7 +35,7 @@ module DB
     #
     # NOTE: For implementors *uri* should be parsed once. If all the options
     # are sound a factory Proc is returned.
-    abstract def connection_builder(uri : URI) : Proc(Connection)
+    abstract def connection_builder(uri : URI) : ConnectionBuilder
 
     def connection_options(params : HTTP::Params) : Connection::Options
       Connection::Options.from_http_params(params)

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -7,7 +7,7 @@ module DB
     record Options,
       # initial number of connections in the pool
       initial_pool_size : Int32 = 1,
-      # maximum amount of connections in the pool (Idle + InUse)
+      # maximum amount of connections in the pool (Idle + InUse). 0 means no maximum.
       max_pool_size : Int32 = 0,
       # maximum amount of idle connections in the pool
       max_idle_pool_size : Int32 = 1,

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -4,6 +4,31 @@ require "./error"
 
 module DB
   class Pool(T)
+    record Options,
+      # initial number of connections in the pool
+      initial_pool_size : Int32 = 1,
+      # maximum amount of connections in the pool (Idle + InUse)
+      max_pool_size : Int32 = 0,
+      # maximum amount of idle connections in the pool
+      max_idle_pool_size : Int32 = 1,
+      # seconds to wait before timeout while doing a checkout
+      checkout_timeout : Float64 = 5.0,
+      # maximum amount of retry attempts to reconnect to the db. See `Pool#retry`
+      retry_attempts : Int32 = 1,
+      # seconds to wait before a retry attempt
+      retry_delay : Float64 = 0.2 do
+      def self.from_http_params(params : HTTP::Params, default = Options.new)
+        Options.new(
+          initial_pool_size: params.fetch("initial_pool_size", default.initial_pool_size).to_i,
+          max_pool_size: params.fetch("max_pool_size", default.max_pool_size).to_i,
+          max_idle_pool_size: params.fetch("max_idle_pool_size", default.max_idle_pool_size).to_i,
+          checkout_timeout: params.fetch("checkout_timeout", default.checkout_timeout).to_f,
+          retry_attempts: params.fetch("retry_attempts", default.retry_attempts).to_i,
+          retry_delay: params.fetch("retry_delay", default.retry_delay).to_f,
+        )
+      end
+    end
+
     # Pool configuration
 
     # initial number of connections in the pool
@@ -37,8 +62,25 @@ module DB
     # global pool mutex
     @mutex : Mutex
 
-    def initialize(@initial_pool_size = 1, @max_pool_size = 0, @max_idle_pool_size = 1, @checkout_timeout = 5.0,
-                   @retry_attempts = 1, @retry_delay = 0.2, &@factory : -> T)
+    @[Deprecated("Use `#new` with DB::Pool::Options instead")]
+    def initialize(initial_pool_size = 1, max_pool_size = 0, max_idle_pool_size = 1, checkout_timeout = 5.0,
+                   retry_attempts = 1, retry_delay = 0.2, &factory : -> T)
+      initialize(
+        Options.new(
+          initial_pool_size: initial_pool_size, max_pool_size: max_pool_size,
+          max_idle_pool_size: max_idle_pool_size, checkout_timeout: checkout_timeout,
+          retry_attempts: retry_attempts, retry_delay: retry_delay),
+        &factory)
+    end
+
+    def initialize(pool_options : Options = Options.new, &@factory : -> T)
+      @initial_pool_size = pool_options.initial_pool_size
+      @max_pool_size = pool_options.max_pool_size
+      @max_idle_pool_size = pool_options.max_idle_pool_size
+      @checkout_timeout = pool_options.checkout_timeout
+      @retry_attempts = pool_options.retry_attempts
+      @retry_delay = pool_options.retry_delay
+
       @availability_channel = Channel(Nil).new
       @waiting_resource = 0
       @inflight = 0

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -523,7 +523,7 @@ module DB
 
     def self.run(description = "as a db")
       ctx = self.new
-      with ctx yield
+      with ctx yield ctx
 
       describe description do
         ctx.include_shared_specs


### PR DESCRIPTION
NOTE: This PR is a breaking-change for drivers implementors, but should not be for driver consumers.

The goal of this PR is to decouple the URI and ConnectionContext structures from the connection initialization.

Driver implementors might be little bit more convoluted since they now will need to return a `DB::ConnectionBuilder` ~~`Proc(DB::Connection)` which usually requires an explicit upcast~~.

A `Database` can now be created more easily with a public API method which enables more complex scenario as #162 and also allows frameworks to create pooled database from other structures than URI.

Pool and Connection configuration have now their own structures which allows simpler overrides for defaults.

crystal-db will still support URI as first class connection strings. That is not going away.

~~Pending: update docs~~ done!