### PR TITLE
Decrement the inflight counter on `ConnectionRefused`

### DIFF
--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -120,8 +120,11 @@ module DB
           resource = if @idle.empty?
                        if can_increase_pool?
                          @inflight += 1
-                         r = unsync { build_resource }
-                         @inflight -= 1
+                         begin
+                           r = unsync { build_resource }
+                         ensure
+                           @inflight -= 1
+                         end
                          r
                        else
                          unsync { wait_for_available }


### PR DESCRIPTION
I decided to take a swing at #169 after adding periodic forced DB failovers (chaos engineering ftw) in addition to occasional actual DB failovers due to real-world things showed that my app would never recover after the failover completed.

After a lot of debugging, I discovered this was only happening when I explicitly set `max_pool_size`. I noticed the number of `DB::ConnectionRefused` exceptions I caught happened to be _exactly_ that number before never occurring again for the life of the process, so I started running `pp db.pool` in a loop and noticed that `inflight` was stuck at that value despite there being no inflight connections — they were failing instantly because the failover hadn't yet completed, but the `@inflight` value was still at the same value as `@max_pool_size` so the pool had no way to know. So it never tried to reconnect after those 30 reconnects because `can_increase_pool?` could never return truthy, so it would just sit there and wait for a connection to become available, and that never happened because `@total` was empty and there were no _actual_ in-flight connections.

I just started using this branch in my app and it now works after a database failover.

This is the same problem #170 is trying to resolve, and I mentioned in [this comment](https://github.com/crystal-lang/crystal-db/pull/170#issuecomment-1499718617) on that PR that it sounded like the existing retry mechanism wasn't working as intended. I also used the reproduction instructions @robcole posted in #169 and the app recovers immediately with this change.

Fixes #169 
Closes #170 