### PR TITLE
Fix max_idle_pool_size race condition

### DIFF
--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -19,6 +19,7 @@ class DummyDriver < DB::Driver
   class DummyConnection < DB::Connection
     def initialize(options : DB::Connection::Options)
       super(options)
+      Fiber.yield
       @connected = true
       @@connections ||= [] of DummyConnection
       @@connections.not_nil! << self
@@ -113,6 +114,7 @@ class DummyDriver < DB::Driver
     end
 
     protected def perform_query(args : Enumerable) : DB::ResultSet
+      Fiber.yield
       @connection.as(DummyConnection).check
       set_params args
       DummyResultSet.new self, command
@@ -161,6 +163,8 @@ class DummyDriver < DB::Driver
 
     def initialize(statement, command)
       super(statement)
+      Fiber.yield
+
       @top_values = command.split.map { |r| r.split(',') }.to_a
       @column_count = @top_values.size > 0 ? @top_values[0].size : 2
 

--- a/spec/manual/load_test.cr
+++ b/spec/manual/load_test.cr
@@ -1,0 +1,54 @@
+# This file is to be executed as:
+#
+# % crystal ./spec/manual/load_test.cr
+#
+# It generated a number of producers and consumers. If the process hangs
+# it means that the connection pool is not working properly. Likely a race condition.
+#
+
+require "../dummy_driver"
+require "../../src/db"
+require "json"
+
+CONNECTION = "dummy://host?initial_pool_size=5&max_pool_size=5&max_idle_pool_size=5"
+
+alias TChannel = Channel(Int32)
+alias TDone = Channel(Bool)
+
+COUNT = 200
+
+def start_consumer(channel : TChannel, done : TDone)
+  spawn do
+    indeces = Set(Int32).new
+    loop do
+      indeces << channel.receive
+      puts "Received size=#{indeces.size}"
+      break if indeces.size == COUNT
+    end
+    done.send true
+  end
+end
+
+def start_producers(channel : TChannel)
+  db = DB.open CONNECTION do |db|
+    sql = "1,title,description,2023 " * 100_000
+
+    COUNT.times do |index|
+      spawn(name: "prod #{index}") do
+        puts "Sending #{index}"
+        _films = db.query_all(sql, as: {Int32, String, String, Int32})
+      rescue ex
+        puts "Error: #{ex.message}"
+      ensure
+        channel.send index
+      end
+    end
+  end
+end
+
+channel = TChannel.new
+done = TDone.new
+start_consumer(channel, done)
+start_producers(channel)
+
+done.receive

--- a/spec/manual/load_test.cr
+++ b/spec/manual/load_test.cr
@@ -2,7 +2,7 @@
 #
 # % crystal ./spec/manual/load_test.cr
 #
-# It generated a number of producers and consumers. If the process hangs
+# It generates a number of producers and consumers. If the process hangs
 # it means that the connection pool is not working properly. Likely a race condition.
 #
 

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -303,10 +303,6 @@ module DB
       sync { @waiting_resource -= 1 }
     end
 
-    private def are_waiting_for_resource?
-      @waiting_resource > 0
-    end
-
     private def sync
       @mutex.lock
       begin

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -200,8 +200,11 @@ module DB
         end
       end
 
-      if idle_pushed && are_waiting_for_resource?
-        @availability_channel.send nil
+      if idle_pushed
+        select
+        when @availability_channel.send(nil)
+        else
+        end
       end
     end
 

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -57,8 +57,6 @@ module DB
 
     # communicate that a connection is available for checkout
     @availability_channel : Channel(Nil)
-    # signal how many existing connections are waited for
-    @waiting_resource : Int32
     # global pool mutex
     @mutex : Mutex
 
@@ -82,7 +80,6 @@ module DB
       @retry_delay = pool_options.retry_delay
 
       @availability_channel = Channel(Nil).new
-      @waiting_resource = 0
       @inflight = 0
       @mutex = Mutex.new
 
@@ -284,23 +281,11 @@ module DB
     end
 
     private def wait_for_available
-      sync_inc_waiting_resource
-
       select
       when @availability_channel.receive
-        sync_dec_waiting_resource
       when timeout(@checkout_timeout.seconds)
-        sync_dec_waiting_resource
         raise DB::PoolTimeout.new("Could not check out a connection in #{@checkout_timeout} seconds")
       end
-    end
-
-    private def sync_inc_waiting_resource
-      sync { @waiting_resource += 1 }
-    end
-
-    private def sync_dec_waiting_resource
-      sync { @waiting_resource -= 1 }
     end
 
     private def sync


### PR DESCRIPTION
Fixes #182

I changed the DummyDriver to simulate IO by introducing a couple of Fiber.yield along the way. This allowed me to extract the load test from #182 without external dependencies and be able to reproduce the race condition. I'm adding these in spec/manual to avoid loosing it.

After fixing the race condition some cleanup lead to dropping the `@waiting_resource` which is good since it implied knowing a bit too much about was happening all the time.

I think the fixed race condition can be stressed by 2 pool clients with a max_pool_size=1 and max_idle_pool_size=1 by the following trace.

- Client A: performs a checkout and eventually yields
- Client B: performs a checkout, the pool is at max capacity and needs to wait, so increments the `@waiting_resource++`, and blocks on the `@availability_channel.receive`
- A: performs a release. `@idle << resource` and wants to `@availability_channel.send`
- Scheduler: the send cause a yield but client b could also experience a timeout
- B: the universe throws a coin and choose to perform a timeout (there is no guarantee what would win)
- B: `@waiting_resource--`, a timeout is raised
- B: The `retry` method which was invoking the `checkout` makes a retry. `@idle` is not empty and can be poped.


B continues with the resource while A is blocked on the `@availability_channel.send`

By using non-blocking sends and dropping the `@waiting_resource` we are embracing better what could happen.
