### PR TITLE
Allow prepared_statements_cache=false option to disable prepared statements cache

### DIFF
--- a/spec/database_spec.cr
+++ b/spec/database_spec.cr
@@ -239,6 +239,24 @@ describe DB::Database do
     end
   end
 
+  describe "prepared_statements_cache connection option" do
+    it "should reuse prepared statements if true" do
+      with_dummy "dummy://localhost:1027?prepared_statements=true&prepared_statements_cache=true" do |db|
+        stmt1 = db.build("the query")
+        stmt2 = db.build("the query")
+        stmt1.object_id.should eq(stmt2.object_id)
+      end
+    end
+
+    it "should not reuse prepared statements if false" do
+      with_dummy "dummy://localhost:1027?prepared_statements=true&prepared_statements_cache=false" do |db|
+        stmt1 = db.build("the query")
+        stmt2 = db.build("the query")
+        stmt1.object_id.should_not eq(stmt2.object_id)
+      end
+    end
+  end
+
   describe "unprepared statements in pool" do
     it "creating statements should not create new connections" do
       with_dummy "dummy://localhost:1027?initial_pool_size=1" do |db|

--- a/spec/statement_spec.cr
+++ b/spec/statement_spec.cr
@@ -34,6 +34,24 @@ describe DB::Statement do
     end
   end
 
+  describe "prepared_statements_cache flag" do
+    it "should reuse prepared statements if true" do
+      with_dummy_connection("prepared_statements=true&prepared_statements_cache=true") do |cnn|
+        stmt1 = cnn.query("the query").statement
+        stmt2 = cnn.query("the query").statement
+        stmt1.object_id.should eq(stmt2.object_id)
+      end
+    end
+
+    it "should not reuse prepared statements if false" do
+      with_dummy_connection("prepared_statements=true&prepared_statements_cache=false") do |cnn|
+        stmt1 = cnn.query("the query").statement
+        stmt2 = cnn.query("the query").statement
+        stmt1.object_id.should_not eq(stmt2.object_id)
+      end
+    end
+  end
+
   it "should initialize positional params in query" do
     with_dummy_connection do |cnn|
       stmt = cnn.prepared("the query").as(DummyDriver::DummyStatement)

--- a/src/db/connection.cr
+++ b/src/db/connection.cr
@@ -25,10 +25,13 @@ module DB
 
     record Options,
       # Return whether the statements should be prepared by default
-      prepared_statements : Bool = true do
+      prepared_statements : Bool = true,
+      # Return whether the prepared statements should be cached or not
+      prepared_statements_cache : Bool = true do
       def self.from_http_params(params : HTTP::Params, default = Options.new)
         Options.new(
-          prepared_statements: DB.fetch_bool(params, "prepared_statements", default.prepared_statements)
+          prepared_statements: DB.fetch_bool(params, "prepared_statements", default.prepared_statements),
+          prepared_statements_cache: DB.fetch_bool(params, "prepared_statements_cache", default.prepared_statements)
         )
       end
     end
@@ -49,7 +52,11 @@ module DB
 
     # :nodoc:
     def fetch_or_build_prepared_statement(query) : Statement
-      @statements_cache.fetch(query) { build_prepared_statement(query) }
+      if @options.prepared_statements_cache
+        @statements_cache.fetch(query) { build_prepared_statement(query) }
+      else
+        build_prepared_statement(query)
+      end
     end
 
     # :nodoc:

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -95,7 +95,11 @@ module DB
 
     # :nodoc:
     def fetch_or_build_prepared_statement(query) : PoolStatement
-      @statements_cache.fetch(query) { build_prepared_statement(query) }
+      if @connection_options.prepared_statements_cache
+        @statements_cache.fetch(query) { build_prepared_statement(query) }
+      else
+        build_prepared_statement(query)
+      end
     end
 
     # :nodoc:


### PR DESCRIPTION
During https://github.com/crystal-lang/crystal-db/pull/178 we came up that it would be nice to be able to tweak whether the prepared statements are cached or not. This option allows the user to opt-out of the statement cache, while still use prepared statements. Some drivers only allow prepared statements.

cc: @luislavena