### PR TITLE
Update mapping macro to support case-insensitive comparisons when matching column name to property name

### DIFF
--- a/spec/mapping_spec.cr
+++ b/spec/mapping_spec.cr
@@ -63,6 +63,12 @@ class MappingWithConverter
   })
 end
 
+class MappingWithCaseInsensitivity
+  DB.mapping({
+    foo: {type: Int32, key: "C0"},
+  }, case_sensitive: false)
+end
+
 macro from_dummy(query, type)
   with_dummy do |db|
     rs = db.query({{ query }})
@@ -144,6 +150,10 @@ describe "DB.mapping" do
 
   it "should initialize a mapping with a value converter" do
     expect_mapping("Zm9v,a", MappingWithConverter, {c0: "foo".to_slice, c1: "a"})
+  end
+
+  it "should perform column name to property name match with case insensitivity" do
+    expect_mapping("1", MappingWithCaseInsensitivity, {foo: 1})
   end
 
   it "should initialize multiple instances from a single resultset" do

--- a/src/db/mapping.cr
+++ b/src/db/mapping.cr
@@ -57,7 +57,7 @@ module DB
   # it and initializes this type's instance variables.
   #
   # This macro also declares instance variables of the types given in the mapping.
-  macro mapping(properties, strict = true)
+  macro mapping(properties, strict = true, case_sensitive = true)
     include ::DB::Mappable
 
     {% for key, value in properties %}
@@ -102,9 +102,9 @@ module DB
       {% end %}
 
       %rs.each_column do |col_name|
-        case col_name
+          case col_name{% if !case_sensitive %}.downcase{% end %}
           {% for key, value in properties %}
-            when {{value[:key] || key.id.stringify}}
+              when {{value[:key] || key.id.stringify}}{% if !case_sensitive %}.downcase{% end %}
               %found{key.id} = true
               %var{key.id} =
                 {% if value[:converter] %}


### PR DESCRIPTION
This pull request adds a `case_sensitive : Bool` parameter to the mapping macro, which defaults to `true` to maintain current behaviour, however when set to `false` it will change the column name to property name matching to be case-insensitive such that any differences in column name case used in the SQL or stored procedure that produced the result set will be ignored and still match the relevant property.

```crystal
DB.mapping({ foo: String }) # => will match column name `foo` only
DB.mapping({ foo: String }, case_sensitive: true) # => will match column name `foo` only
DB.mapping({ foo: String }, case_sensitive: false) # => will match column name `foo` or `FOO` or `Foo` or `fOo` etc.
```