### PR TITLE
Deprecate `DB.mapping`

### DIFF
--- a/src/db/mapping.cr
+++ b/src/db/mapping.cr
@@ -1,5 +1,6 @@
 module DB
   # Empty module used for marking a class as supporting DB:Mapping
+  @[Deprecated("Use `DB::Serializable` instead")]
   module Mappable; end
 
   # The `DB.mapping` macro defines how an object is built from a `ResultSet`.
@@ -57,6 +58,7 @@ module DB
   # it and initializes this type's instance variables.
   #
   # This macro also declares instance variables of the types given in the mapping.
+  @[Deprecated("Use `DB::Serializable` instead")]
   macro mapping(properties, strict = true)
     include ::DB::Mappable
 
@@ -148,6 +150,7 @@ module DB
     end
   end
 
+  @[Deprecated("Use `DB::Serializable` instead")]
   macro mapping(**properties)
     ::DB.mapping({{properties}})
   end


### PR DESCRIPTION
[`DB::Serializable`](https://crystal-lang.github.io/crystal-db/api/0.12.0/DB/Serializable.html) has been around for a long time and is a more versatile tool.
The equivalents `JSON.mapping` and `YAML.mapping` in stdlib are long gone and replaced by `*::Serializable`.

cf. https://github.com/crystal-lang/crystal-db/pull/195#issuecomment-1802215887