### PR TITLE
Allow statements to auto close when consumed if no cache

### DIFF
--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -34,14 +34,20 @@ class DummyDriver < DB::Driver
     end
 
     def build_prepared_statement(query) : DB::Statement
+      assert_not_closed!
+
       DummyStatement.new(self, query, true)
     end
 
     def build_unprepared_statement(query) : DB::Statement
+      assert_not_closed!
+
       DummyStatement.new(self, query, false)
     end
 
     def last_insert_id : Int64
+      assert_not_closed!
+
       0
     end
 
@@ -54,11 +60,17 @@ class DummyDriver < DB::Driver
     end
 
     def create_transaction
+      assert_not_closed!
+
       DummyTransaction.new(self)
     end
 
     protected def do_close
       super
+    end
+
+    private def assert_not_closed!
+      raise "Statement is closed" if closed?
     end
   end
 
@@ -114,6 +126,8 @@ class DummyDriver < DB::Driver
     end
 
     protected def perform_query(args : Enumerable) : DB::ResultSet
+      assert_not_closed!
+
       Fiber.yield
       @connection.as(DummyConnection).check
       set_params args
@@ -121,6 +135,8 @@ class DummyDriver < DB::Driver
     end
 
     protected def perform_exec(args : Enumerable) : DB::ExecResult
+      assert_not_closed!
+
       @connection.as(DummyConnection).check
       set_params args
       raise DB::Error.new("forced exception due to query") if command == "raise"
@@ -152,6 +168,10 @@ class DummyDriver < DB::Driver
 
     protected def do_close
       super
+    end
+
+    private def assert_not_closed!
+      raise "Statement is closed" if closed?
     end
   end
 

--- a/spec/statement_spec.cr
+++ b/spec/statement_spec.cr
@@ -43,11 +43,33 @@ describe DB::Statement do
       end
     end
 
+    it "should leave statements open to be reused if true" do
+      with_dummy_connection("prepared_statements=true&prepared_statements_cache=true") do |cnn|
+        rs = cnn.query("the query")
+        # do not close while iterating
+        rs.statement.closed?.should be_false
+        rs.close
+        # do not close to be reused
+        rs.statement.closed?.should be_false
+      end
+    end
+
     it "should not reuse prepared statements if false" do
       with_dummy_connection("prepared_statements=true&prepared_statements_cache=false") do |cnn|
         stmt1 = cnn.query("the query").statement
         stmt2 = cnn.query("the query").statement
         stmt1.object_id.should_not eq(stmt2.object_id)
+      end
+    end
+
+    it "should close statements if false" do
+      with_dummy_connection("prepared_statements=true&prepared_statements_cache=false") do |cnn|
+        rs = cnn.query("the query")
+        # do not close while iterating
+        rs.statement.closed?.should be_false
+        rs.close
+        # do close after iterating
+        rs.statement.closed?.should be_true
       end
     end
   end

--- a/spec/statement_spec.cr
+++ b/spec/statement_spec.cr
@@ -72,6 +72,20 @@ describe DB::Statement do
         rs.statement.closed?.should be_true
       end
     end
+
+    it "should not close statements if false and created explicitly" do
+      with_dummy_connection("prepared_statements=true&prepared_statements_cache=false") do |cnn|
+        stmt = cnn.prepared("the query")
+
+        rs = stmt.query
+        # do not close while iterating
+        stmt.closed?.should be_false
+        rs.close
+
+        # do not close after iterating
+        stmt.closed?.should be_false
+      end
+    end
   end
 
   it "should initialize positional params in query" do

--- a/src/db/connection.cr
+++ b/src/db/connection.cr
@@ -50,14 +50,16 @@ module DB
       @options.prepared_statements
     end
 
+    def prepared_statements_cache? : Bool
+      @options.prepared_statements_cache
+    end
+
     # :nodoc:
     def fetch_or_build_prepared_statement(query) : Statement
       if @options.prepared_statements_cache
         @statements_cache.fetch(query) { build_prepared_statement(query) }
       else
-        stmt = build_prepared_statement(query)
-        stmt.auto_close = true
-        stmt
+        build_prepared_statement(query)
       end
     end
 

--- a/src/db/connection.cr
+++ b/src/db/connection.cr
@@ -55,7 +55,9 @@ module DB
       if @options.prepared_statements_cache
         @statements_cache.fetch(query) { build_prepared_statement(query) }
       else
-        build_prepared_statement(query)
+        stmt = build_prepared_statement(query)
+        stmt.auto_close = true
+        stmt
       end
     end
 

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -59,6 +59,10 @@ module DB
       @connection_options.prepared_statements
     end
 
+    def prepared_statements_cache? : Bool
+      @connection_options.prepared_statements_cache
+    end
+
     # Run the specified block every time a new connection is established, yielding the new connection
     # to the block.
     #

--- a/src/db/pool_prepared_statement.cr
+++ b/src/db/pool_prepared_statement.cr
@@ -15,7 +15,14 @@ module DB
       # otherwise the preparation is delayed until the first execution.
       # After the first initialization the connection must be released
       # it will be checked out when executing it.
-      statement_with_retry &.release_connection
+
+      # This only happens if the db is configured to use prepared statements cache.
+      # Without that there is no reference to the already prepared statement we can
+      # take advantage of.
+      if db.prepared_statements_cache?
+        statement_with_retry &.release_connection
+      end
+
       # TODO use a round-robin selection in the pool so multiple sequentially
       #      initialized statements are assigned to different connections.
     end

--- a/src/db/pool_prepared_statement.cr
+++ b/src/db/pool_prepared_statement.cr
@@ -53,7 +53,7 @@ module DB
         conn.release
         raise ex
       end
-      unless existing
+      if !existing && @db.prepared_statements_cache?
         @mutex.synchronize do
           @connections << WeakRef.new(conn)
         end
@@ -62,6 +62,8 @@ module DB
     end
 
     private def clean_connections
+      return unless @db.prepared_statements_cache?
+
       @mutex.synchronize do
         # remove disposed or closed connections
         @connections.each do |ref|

--- a/src/db/result_set.cr
+++ b/src/db/result_set.cr
@@ -29,7 +29,7 @@ module DB
     end
 
     protected def do_close
-      statement.release_connection
+      statement.release_from_result_set
     end
 
     # TODO add_next_result_set : Bool

--- a/src/db/statement.cr
+++ b/src/db/statement.cr
@@ -56,6 +56,15 @@ module DB
     def initialize(@connection : Connection, @command : String)
     end
 
+    # :nodoc:
+    property auto_close : Bool = false
+
+    # :nodoc:
+    def release_from_result_set
+      self.close if @auto_close
+      self.release_connection
+    end
+
     def release_connection
       @connection.release_from_statement
     end


### PR DESCRIPTION
Follow up to #194, to play nicer with statement lifecycle.

Before this PR when the result set finish iterating the results the connection was released but the statements no because they were always retained for later. With the option of no caching we need to properly close them. sqlite3 is strict about this but is good for every engine.

~I want to add some specs before merging. 🙈~

cc: @luislavena, it seems to fix the issue you found. Let me know if you are able to break it ;-)