### PR TITLE
Add exception cause support to `PoolResourceLost` and `ConnectionLost` constructors

### DIFF
--- a/src/db/error.cr
+++ b/src/db/error.cr
@@ -30,7 +30,8 @@ module DB
   class PoolResourceLost(T) < Error
     getter resource : T
 
-    def initialize(@resource : T)
+    def initialize(@resource : T, cause : Exception? = nil)
+      super(cause: cause)
       @resource.close
     end
   end


### PR DESCRIPTION
Implementing database drivers are required to raise a `ConnectionLost` error when they detect an existing connection has gone bad (such as when a firewall or server resets the connection). However the original exception (probably `IO::Error`) is lost. I'd really like to be able to see the original exception (and especially it's stack trace) which caused the `ConnectionLost` error to be thrown, because it will help diagnose / investigate whatever caused the issue (i.e. it could be caused by a defect in the database driver, rather than a true bad connection).

This pull request updates the `PoolResourceLost` (and is inherited to `ConnectionLost`) constructor to add the missing optional `cause` parameter that is available on the base `Exception` class.

Obviously then it will be up to the database drivers to include the cause when raising `ConnectionLost`.

Thanks for your consideration!