### PR TITLE
`crystal tool format` with Crystal 1.15.0-dev

### DIFF
--- a/spec/dummy_driver.cr
+++ b/spec/dummy_driver.cr
@@ -319,13 +319,13 @@ class Witness
   end
 end
 
-def with_witness(count = 1)
+def with_witness(count = 1, &)
   w = Witness.new(count)
   yield w
   w.count.should eq(0), "The expected coverage was unmet"
 end
 
-def with_dummy(uri : String = "dummy://host?checkout_timeout=0.5")
+def with_dummy(uri : String = "dummy://host?checkout_timeout=0.5", &)
   DummyDriver::DummyConnection.clear_connections
 
   DB.open uri do |db|
@@ -333,7 +333,7 @@ def with_dummy(uri : String = "dummy://host?checkout_timeout=0.5")
   end
 end
 
-def with_dummy_connection(options = "")
+def with_dummy_connection(options = "", &)
   with_dummy("dummy://host?checkout_timeout=0.5&#{options}") do |db|
     db.using_connection do |cnn|
       yield cnn.as(DummyDriver::DummyConnection)

--- a/spec/pool_spec.cr
+++ b/spec/pool_spec.cr
@@ -9,7 +9,7 @@ class ShouldSleepingOp
     @sleep_happened = Channel(Nil).new
   end
 
-  def should_sleep
+  def should_sleep(&)
     s = self
     @is_sleeping = true
     spawn do

--- a/spec/save_point_transaction_spec.cr
+++ b/spec/save_point_transaction_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 private class FooException < Exception
 end
 
-private def with_dummy_top_transaction
+private def with_dummy_top_transaction(&)
   with_dummy_connection do |cnn|
     cnn.transaction do |tx|
       yield tx.as(DummyDriver::DummyTransaction), cnn
@@ -11,7 +11,7 @@ private def with_dummy_top_transaction
   end
 end
 
-private def with_dummy_nested_transaction
+private def with_dummy_nested_transaction(&)
   with_dummy_connection do |cnn|
     cnn.transaction do |tx|
       tx.transaction do |nested|

--- a/spec/support/http.cr
+++ b/spec/support/http.cr
@@ -1,7 +1,7 @@
 require "http"
 require "./fibers"
 
-def wait_for(timeout = 5.seconds)
+def wait_for(timeout = 5.seconds, &)
   now = Time.monotonic
 
   until yield
@@ -22,7 +22,7 @@ end
 #    shut down before continuing execution in the current fiber.
 # 6. If the listening fiber raises an exception, it is rescued and re-raised
 #    in the current fiber.
-def run_server(server)
+def run_server(server, &)
   server_done = Channel(Exception?).new
 
   f = spawn do

--- a/src/db.cr
+++ b/src/db.cr
@@ -161,7 +161,7 @@ module DB
     connection_options = driver.connection_options(params)
     pool_options = driver.pool_options(params)
     builder = driver.connection_builder(uri)
-    factory = ->{ builder.build }
+    factory = -> { builder.build }
     Database.new(connection_options, pool_options, &factory)
   end
 

--- a/src/db/database.cr
+++ b/src/db/database.cr
@@ -43,7 +43,7 @@ module DB
     # This covers more advanced use cases that might not be supported by an URI connection string such as tunneling connection.
     def initialize(connection_options : Connection::Options, pool_options : Pool::Options, &factory : -> Connection)
       @connection_options = connection_options
-      @setup_connection = ->(conn : Connection) {}
+      @setup_connection = ->(conn : Connection) { }
       @pool = uninitialized Pool(Connection) # in order to use self in the factory proc
       @pool = Pool(Connection).new(pool_options) {
         conn = factory.call
@@ -111,7 +111,7 @@ module DB
     # yields a connection from the pool
     # the connection is returned to the pool
     # when the block ends
-    def using_connection
+    def using_connection(&)
       connection = self.checkout
       begin
         yield connection
@@ -131,7 +131,7 @@ module DB
 
     # yields a `Transaction` from a connection of the pool
     # Refer to `BeginTransaction#transaction` for documentation.
-    def transaction
+    def transaction(&)
       using_connection do |cnn|
         cnn.transaction do |tx|
           yield tx
@@ -140,7 +140,7 @@ module DB
     end
 
     # :nodoc:
-    def retry
+    def retry(&)
       @pool.retry do
         yield
       end

--- a/src/db/enumerable_concat.cr
+++ b/src/db/enumerable_concat.cr
@@ -6,7 +6,7 @@ module DB
     def initialize(@e1 : T, @e2 : U)
     end
 
-    def each
+    def each(&)
       if e1 = @e1
         @e1.each do |e|
           yield e

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -188,7 +188,7 @@ module DB
     # Will retry the block if a `ConnectionLost` exception is thrown.
     # It will try to reuse all of the available connection right away,
     # but if a new connection is needed there is a `retry_delay` seconds delay.
-    def retry
+    def retry(&)
       current_available = 0
 
       sync do
@@ -217,7 +217,7 @@ module DB
     end
 
     # :nodoc:
-    def each_resource
+    def each_resource(&)
       sync do
         @idle.each do |resource|
           yield resource
@@ -265,7 +265,7 @@ module DB
       end
     end
 
-    private def sync
+    private def sync(&)
       @mutex.lock
       begin
         yield
@@ -274,7 +274,7 @@ module DB
       end
     end
 
-    private def unsync
+    private def unsync(&)
       @mutex.unlock
       begin
         yield

--- a/src/db/pool_statement.cr
+++ b/src/db/pool_statement.cr
@@ -38,7 +38,7 @@ module DB
     # the conneciton is registered in `@connections`
     private abstract def build_statement : Statement
 
-    private def statement_with_retry
+    private def statement_with_retry(&)
       @db.retry do
         return yield build_statement
       end

--- a/src/db/query_methods.cr
+++ b/src/db/query_methods.cr
@@ -56,7 +56,7 @@ module DB
     #   end
     # end
     # ```
-    def query(query, *args_, args : Enumerable? = nil)
+    def query(query, *args_, args : Enumerable? = nil, &)
       # CHECK build(query).query(*args, &block)
       rs = query(query, *args_, args: args)
       yield rs ensure rs.close
@@ -262,7 +262,7 @@ module DB
     #   puts rs.read(String)
     # end
     # ```
-    def query_each(query, *args_, args : Enumerable? = nil)
+    def query_each(query, *args_, args : Enumerable? = nil, &)
       query(query, *args_, args: args) do |rs|
         rs.each do
           yield rs

--- a/src/db/result_set.cr
+++ b/src/db/result_set.cr
@@ -35,14 +35,14 @@ module DB
     # TODO add_next_result_set : Bool
 
     # Iterates over all the rows
-    def each
+    def each(&)
       while move_next
         yield
       end
     end
 
     # Iterates over all the columns
-    def each_column
+    def each_column(&)
       column_count.times do |x|
         yield column_name(x)
       end

--- a/src/db/statement.cr
+++ b/src/db/statement.cr
@@ -14,7 +14,7 @@ module DB
     end
 
     # See `QueryMethods#query`
-    def query(*args_, args : Enumerable? = nil)
+    def query(*args_, args : Enumerable? = nil, &)
       rs = query(*args_, args: args)
       yield rs ensure rs.close
     end
@@ -113,7 +113,7 @@ module DB
     # This method is called when executing the statement. Although it can be
     # redefined, it is recommended to use the `def_around_query_or_exec` macro
     # to be able to add new behaviors without loosing prior existing ones.
-    protected def around_query_or_exec(args : Enumerable)
+    protected def around_query_or_exec(args : Enumerable, &)
       yield
     end
 

--- a/src/db/string_key_cache.cr
+++ b/src/db/string_key_cache.cr
@@ -2,13 +2,13 @@ module DB
   class StringKeyCache(T)
     @cache = {} of String => T
 
-    def fetch(key : String) : T
+    def fetch(key : String, &) : T
       value = @cache.fetch(key, nil)
       value = @cache[key] = yield unless value
       value
     end
 
-    def each_value
+    def each_value(&)
       @cache.each do |_, value|
         yield value
       end

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -51,8 +51,8 @@ module DB
   class DriverSpecs(DBAnyType)
     record ColumnDef, name : String, sql_type : String, null : Bool
 
-    @before : Proc(Nil) = ->{}
-    @after : Proc(Nil) = ->{}
+    @before : Proc(Nil) = -> { }
+    @after : Proc(Nil) = -> { }
     @encode_null = "NULL"
     @support_prepared = true
     @support_unprepared = true
@@ -394,7 +394,7 @@ module DB
     end
 
     # :nodoc:
-    def with_db(options = nil)
+    def with_db(options = nil, &)
       @before.call
 
       if options
@@ -534,7 +534,7 @@ module DB
       drop_table_if_exists_syntax.call(table_name)
     end
 
-    def self.run(description = "as a db")
+    def self.run(description = "as a db", &)
       ctx = self.new
       with ctx yield ctx
 


### PR DESCRIPTION
Crystal nightly has a couple new formatter rules enabled: https://github.com/crystal-lang/crystal/pull/14718
The changes are backwards-compatible, so Crystal 1.14.0 won't complain about the new format.