### PR TITLE
Replaced deprecated splat operator

### DIFF
--- a/src/db.cr
+++ b/src/db.cr
@@ -89,7 +89,7 @@ module DB
 
   # See `DB::TYPES` in `DB`. `Any` is a union of all types in `DB::TYPES`
   {% begin %}
-    alias Any = Union({{*TYPES}})
+    alias Any = Union({{TYPES.splat}})
   {% end %}
 
   # Result of a `#exec` statement.


### PR DESCRIPTION
Came across this deprecation warning when running `crystal tool dependencies` in another projects

```cr
In lib/db/src/db.cr:92:26

 92 | alias Any = Union({{*TYPES}})
                           ^
Warning: Deprecated use of splat operator. Use `#splat` instead
```