### PR TITLE
Add ability to expire resources within the pool

### DIFF
--- a/spec/pool_spec.cr
+++ b/spec/pool_spec.cr
@@ -307,7 +307,7 @@ describe DB::Pool do
     # by the lifetime expiration instead.
     2.times {
       pool.checkout {
-        sleep 0.6
+        sleep 0.6.seconds
       }
     }
 
@@ -332,7 +332,7 @@ describe DB::Pool do
     # Initially have 3 clients
     all.size.should eq(3)
 
-    sleep 0.6
+    sleep 0.6.seconds
 
     # checkout
     3.times do |i|
@@ -368,7 +368,7 @@ describe DB::Pool do
     }
 
     # Await lifetime expiration
-    sleep 2.1
+    sleep 2.1.seconds
     # release
     temp_resource_store.each_with_index do |resource, i|
       # All three idle connections were checked out
@@ -396,12 +396,12 @@ describe DB::Pool do
       # Create 5 resource
       5.times {
         spawn do
-          pool.checkout { sleep 0.1 }
+          pool.checkout { sleep 0.1.seconds }
         end
       }
 
       # Don't do anything for 5 seconds
-      sleep 5
+      sleep 5.seconds
 
       # Gone
       all.each &.closed?.should be_true

--- a/src/db/error.cr
+++ b/src/db/error.cr
@@ -39,6 +39,18 @@ module DB
   class PoolResourceRefused < Error
   end
 
+  # Raised when a checked out resource has reached expiration of any kind
+  class PoolResourceExpired(T) < PoolResourceLost(T)
+  end
+
+  # Raised when a checked out resource has exceeded the maximum lifetime
+  class PoolResourceLifetimeExpired(T) < PoolResourceExpired(T)
+  end
+
+  # Raised when a checked out resource has idle expired
+  class PoolResourceIdleExpired(T) < PoolResourceExpired(T)
+  end
+
   # Raised when an established connection is lost
   # probably due to socket/network issues.
   # It is used by the connection pool retry logic.

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -175,6 +175,7 @@ module DB
       @total.each &.close
       @total.clear
       @idle.clear
+      @resource_lifecycle.clear
       @sweep_job_close_channel.send(nil) if @sweep_job_running
     end
 

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -16,7 +16,11 @@ module DB
       # maximum amount of retry attempts to reconnect to the db. See `Pool#retry`
       retry_attempts : Int32 = 1,
       # seconds to wait before a retry attempt
-      retry_delay : Float64 = 0.2 do
+      retry_delay : Float64 = 0.2,
+      # maximum number of seconds the resource can persist after being created. 0 to disable.
+      max_lifetime_per_resource : Float64 = 0.0,
+      # maximum number of seconds an idle resource can remain unused for being removed. 0 to disable.
+      max_idle_time_per_resource : Float64 = 0.0 do
       def self.from_http_params(params : HTTP::Params, default = Options.new)
         Options.new(
           initial_pool_size: params.fetch("initial_pool_size", default.initial_pool_size).to_i,
@@ -43,6 +47,11 @@ module DB
     @retry_attempts : Int32
     # seconds to wait before a retry attempt
     @retry_delay : Float64
+
+    # maximum number of seconds the resource can persist after being created. 0 to disable.
+    @max_lifetime_per_resource : Float64
+    # maximum number of seconds an idle resource can remain unused for being removed. 0 to disable.
+    @max_idle_time_per_resource : Float64
 
     # Pool state
 
@@ -78,6 +87,8 @@ module DB
       @checkout_timeout = pool_options.checkout_timeout
       @retry_attempts = pool_options.retry_attempts
       @retry_delay = pool_options.retry_delay
+      @max_lifetime_per_resource = pool_options.max_lifetime_per_resource
+      @max_idle_time_per_resource = pool_options.max_idle_time_per_resource
 
       @availability_channel = Channel(Nil).new
       @inflight = 0


### PR DESCRIPTION
Closes #47

This PR implements the ability to expire assets within the pool based on what I think was discussed in #47

This is configured through the two new pool parameters `max_lifetime_per_resource` and `max_idle_time_per_resource` which sets the number of seconds before they get expired and removed from the pool. This is done on each `#checkout` and `#release`  but also with an optional background fiber which runs on either a configured timer, or whichever configured expiration is shorter.

This PR mostly also respects `initial_pool_size` in that it'll try to keep at least that many resources within the pool--but it doesn't actually know which resources are stale until it checks on a `#checkout/#release` or with the background fiber so they're not necessarily always fresh.

But if any of the expiration check causes the amount of resources within pool to drop below `initial_pool_size` it'll immediately replenish with fresh resources till its back up to `initial_pool_size`.

Also when a `#checkout` internally finds an expired resource, the new `PoolResourceExpired` exception is raised. So `#retry` will get more important.

The specs all seems to pass and modifying the manual specs to use the new expiration features did not show any glaring problems either. 

Please let me know if I've missed something with this implementation! I wrote this over the course of a single night so apologies in advance if the code might be a bit messy 😅