### PR TITLE
Exclude macos-latest 1.0.0 check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         crystal: [1.0.0, latest, nightly]
+        exclude:
+          - os: macos-latest
+            crystal: 1.0.0
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
The compatibility check for osx and crystal 1.0.0 has been failing for quite a long time.

We still do a crystal 1.0.0 check against ubuntu and that should be sufficient probably to catch any breaking change in the api. So in this PR I am proposing to exclude the osx-crystal-1.0.0 check.

In https://github.com/crystal-lang/crystal-mysql/pull/114 we also lift the check from 1.0.0 to 1.3.0 due to openssl availability.

```
[test (macos-latest, 1.0.0)](https://github.com/crystal-lang/crystal-db/actions/runs/13491783278/job/37691082989#step:2:16)
Error: Command failed: shards --version
dyld[3049]: Library not loaded: /opt/crystal/embedded/lib/libyaml-0.2.dylib
  Referenced from: <853D3C00-48FB-3856-A9FE-95DFEDB25BF7> /Users/runner/work/_temp/crystal-1.0.0-true-undefined/embedded/bin/shards
  Reason: tried: '/opt/crystal/embedded/lib/libyaml-0.2.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/crystal/embedded/lib/libyaml-0.2.dylib' (no such file), '/opt/crystal/embedded/lib/libyaml-0.2.dylib' (no such file), '/usr/local/lib/libyaml-0.2.dylib' (no such file), '/usr/lib/libyaml-0.2.dylib' (no such file, not in dyld cache)
```