### PR TITLE
Log Range as string representation rather than array

### DIFF
--- a/src/db/statement.cr
+++ b/src/db/statement.cr
@@ -181,6 +181,11 @@ module DB
     end
 
     # :ditto:
+    def self.arg_to_log(arg : Range) : ::Log::Metadata::Value
+      ::Log::Metadata::Value.new(arg.to_s)
+    end
+
+    # :ditto:
     def self.arg_to_log(arg : Int) : ::Log::Metadata::Value
       ::Log::Metadata::Value.new(arg.to_i64)
     end


### PR DESCRIPTION
Discovered while implementing support for PostgreSQL ranges in https://github.com/will/crystal-pg/pull/304.

I encountered an issue where `Range` arguments containing `Time` objects would cause logging failures:

```
(Time.utc(2016, 2, 15, 10, 20, 30)..Time.utc(2017, 2, 15, 10, 20, 30)).to_a
# Error: undefined method 'succ' for Time
```

The existing `MetadataValueConverter.arg_to_log(arg : Enumerable)` method attempts to convert ranges to an array, which fails for `Time` ranges.