### PR TITLE
Check whether pool resource was closed in `before_checkout` hook, allowing for health checks and max-TTL connections

### DIFF
--- a/spec/pool_spec.cr
+++ b/spec/pool_spec.cr
@@ -57,6 +57,19 @@ class Closable
   end
 end
 
+class Expirable
+  include DB::Disposable
+
+  property? expired = false
+
+  def before_checkout
+    close if expired?
+  end
+
+  private def do_close
+  end
+end
+
 private def create_pool(**options, &factory : -> T) forall T
   DB::Pool.new(DB::Pool::Options.new(**options), &factory)
 end
@@ -192,6 +205,19 @@ describe DB::Pool do
     all[0].closed?.should be_false
     all[1].closed?.should be_true
     all[2].closed?.should be_false
+  end
+
+  it "should not return closed resources from checkout" do
+    pool = create_pool(max_pool_size: 1, max_idle_pool_size: 1) { Expirable.new }
+
+    resource1 = pool.checkout
+    pool.release resource1
+
+    # Expired while idle
+    resource1.expired = true
+
+    resource2 = pool.checkout
+    resource2.should_not eq resource1
   end
 
   it "should not return closed resources to the pool" do

--- a/src/db/pool.cr
+++ b/src/db/pool.cr
@@ -135,16 +135,24 @@ module DB
                      else
                        pick_available
                      end
-        end
 
-        @idle.delete resource
+          if resource
+            if resource.responds_to?(:before_checkout)
+              resource.before_checkout
+            end
+
+            @idle.delete resource
+
+            if resource.responds_to?(:closed?) && resource.closed?
+              @total.delete resource
+              resource = nil
+            end
+          end
+        end
 
         resource
       end
 
-      if res.responds_to?(:before_checkout)
-        res.before_checkout
-      end
       res
     end
 


### PR DESCRIPTION
This PR allows pool resources to do things like run health checks before returning from `checkout` to make sure the connection is healthy:

```crystal
class PG::Connection
  getter last_health_check = Time.instant

  def before_checkout
    if last_health_check.elapsed > 1.minute
      exec "SELECT 1" 
      @last_health_check = Time.instant
    end
  rescue ex : IO::Error
    close
  end
end
```

Shopify does something similar to this. At the beginning of a request, they ping the MySQL server (via [the `trilogy` adapter](https://github.com/trilogy-libraries/trilogy)) to ensure the connection is alive and, if not, they explicitly close it, which causes ActiveRecord's connection pool to open a new one, possibly to a different replica entirely.

This PR can also be used to allow connections to have a max TTL. The driver's `DB::Connection` subclass can have a `before_checkout` that checks against a TTL. For example:

```crystal
class PG::Connection
  getter opened_at = Time.instant
  property ttl = 1.hour

  def before_checkout
    close if opened_at.elapsed > ttl
  end
end
```

Fixes #225 