### PR TITLE
Added Mimer SQL to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Common db api for crystal. You will need to have a specific driver to access a d
 * [Cassandra](https://github.com/kaukas/crystal-cassandra)
 * [DuckDB](https://github.com/amauryt/crystal-duckdb)
 * [Microsoft SQL Server](https://github.com/wonderix/crystal-tds)
+* [Mimer SQL](https://github.com/majorproblem/crystal-mimer)
 
 ## Installation
 


### PR DESCRIPTION
I have written a driver for the relational database [Mimer SQL](https://mimer.com) that uses crystal-db, and I would like to add that to the list of drivers.